### PR TITLE
Add Django toolkit

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Here at DataMade, we do a lot of computer programming. In the spirit of [better 
     - [How to move a gpg key between servers](/shell/moving-keys-between-servers.md)
 - [Amazon Web Services](/aws/)
     - [AWS Relational Database Service (RDS)](/aws/rds.md)
+- [Django](/django/) - Preferred plugins for common functionality
 
 ## Contributing
 

--- a/django/README.md
+++ b/django/README.md
@@ -11,3 +11,5 @@ In some cases, it also provides extended documentation for setup and use.
 | Search | [`django-haystack`](https://github.com/django-haystack/django-haystack) | |
 | Autocomplete | [`django-autocomplete-light`](https://github.com/yourlabs/django-autocomplete-light) | |
 | Cross-browser ES6 support | [`django-compressor`](https://github.com/django-compressor/django-compressor) + [`django-compressor-toolkit`](https://github.com/kottenator/django-compressor-toolkit) | [Link](django-compressor.md) |
+| Content management system | [`django-cms`](https://github.com/divio/django-cms) | [Link](django-cms.md) |
+| API | [`django-rest-framework`](https://github.com/encode/django-rest-framework) + [`django-cors-headers`](https://github.com/ottoyiu/django-cors-headers) | [Link](django-rest-framework.md) |

--- a/django/README.md
+++ b/django/README.md
@@ -1,13 +1,13 @@
 # Django
 
-This directory catalogs our preferred Django extensions for common application
-objectives. In some cases, it also provides extended documentation for setup
-and use.
+This directory catalogs our preferred Django extensions for common functionality.
+In some cases, it also provides extended documentation for setup and use.
 
 ## Standard toolkit
 
 | Objective | Library | Internal documentation |
 | :- | :- | :- |
+| Debugging | [`django-debug-toolbar`](https://github.com/jazzband/django-debug-toolbar) + [`django-debug-toolbar-request-history`](https://github.com/djsutho/django-debug-toolbar-request-history) | |
 | Search | [`django-haystack`](https://github.com/django-haystack/django-haystack) | |
 | Autocomplete | [`django-autocomplete-light`](https://github.com/yourlabs/django-autocomplete-light) | |
 | Cross-browser ES6 support | [`django-compressor`](https://github.com/django-compressor/django-compressor) + [`django-compressor-toolkit`](https://github.com/kottenator/django-compressor-toolkit) | [Link](django-compressor.md) |

--- a/django/README.md
+++ b/django/README.md
@@ -1,0 +1,11 @@
+# Django
+
+This directory catalogs our preferred Django extensions for common application
+objectives. In some cases, it also provides extended documentation for setup
+and use.
+
+## Standard toolkit
+
+| Objective | Library | Internal documentation |
+| :- | :- | :- |
+| Cross-browser ES6 support | [`django-compressor`](https://github.com/django-compressor/django-compressor) + [`django-compressor-toolkit`](https://github.com/kottenator/django-compressor-toolkit) | [Link](django-compressor.md) |

--- a/django/README.md
+++ b/django/README.md
@@ -11,5 +11,4 @@ In some cases, it also provides extended documentation for setup and use.
 | Search | [`django-haystack`](https://github.com/django-haystack/django-haystack) | |
 | Autocomplete | [`django-autocomplete-light`](https://github.com/yourlabs/django-autocomplete-light) | |
 | Cross-browser ES6 support | [`django-compressor`](https://github.com/django-compressor/django-compressor) + [`django-compressor-toolkit`](https://github.com/kottenator/django-compressor-toolkit) | [Link](django-compressor.md) |
-| Content management system | [`django-cms`](https://github.com/divio/django-cms) | [Link](django-cms.md) |
 | API | [`django-rest-framework`](https://github.com/encode/django-rest-framework) + [`django-cors-headers`](https://github.com/ottoyiu/django-cors-headers) | [Link](django-rest-framework.md) |

--- a/django/README.md
+++ b/django/README.md
@@ -8,4 +8,6 @@ and use.
 
 | Objective | Library | Internal documentation |
 | :- | :- | :- |
+| Search | [`django-haystack`](https://github.com/django-haystack/django-haystack) | |
+| Autocomplete | [`django-autocomplete-light`](https://github.com/yourlabs/django-autocomplete-light) | |
 | Cross-browser ES6 support | [`django-compressor`](https://github.com/django-compressor/django-compressor) + [`django-compressor-toolkit`](https://github.com/kottenator/django-compressor-toolkit) | [Link](django-compressor.md) |

--- a/django/django-cms.md
+++ b/django/django-cms.md
@@ -1,3 +1,0 @@
-# django-cms
-
-Pilot: _tk._

--- a/django/django-cms.md
+++ b/django/django-cms.md
@@ -1,0 +1,3 @@
+# django-cms
+
+Pilot: _tk._

--- a/django/django-compressor.md
+++ b/django/django-compressor.md
@@ -1,0 +1,5 @@
+# django-compressor
+
+Pilot: https://github.com/datamade/bga-pensions/pull/1
+
+_tk._

--- a/django/django-rest-framework.md
+++ b/django/django-rest-framework.md
@@ -1,0 +1,3 @@
+# django-rest-framework
+
+Pilot: _tk._

--- a/django/django-rest-framework.md
+++ b/django/django-rest-framework.md
@@ -1,3 +1,3 @@
 # django-rest-framework
 
-Pilot: _tk._
+_tk._


### PR DESCRIPTION
This PR adds a directory for Django and begins a table enumerating our preferred plugins for common use cases. It also adds stub documentation for `django-compressor` and `django-compressor-toolkit`. 

Related to #22.