### PR TITLE
Initialize UX folder with doc for Project Research and Interviews

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ Here at DataMade, we do a lot of computer programming. In the spirit of [better 
     - [How to move a gpg key between servers](/shell/moving-keys-between-servers.md)
 - [Amazon Web Services](/aws/)
     - [AWS Relational Database Service (RDS)](/aws/rds.md)
+- [User Experience (UX)][/ux/]
+    - [Project research and interviews](/ux/project-research-and-interviews.md)
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Here at DataMade, we do a lot of computer programming. In the spirit of [better 
     - [How to move a gpg key between servers](/shell/moving-keys-between-servers.md)
 - [Amazon Web Services](/aws/)
     - [AWS Relational Database Service (RDS)](/aws/rds.md)
-- [User Experience (UX)][/ux/]
+- [User Experience (UX)](/ux/)
     - [Project research and interviews](/ux/project-research-and-interviews.md)
 
 ## Contributing

--- a/ux/README.md
+++ b/ux/README.md
@@ -1,0 +1,7 @@
+# User Experience (UX)
+
+This directory records best practices for researching and implementing user experience (UX) design.
+
+## Guides
+
+- [Project research and interviews](/ux/project-research-and-interviews.md)

--- a/ux/project-research-and-interviews.md
+++ b/ux/project-research-and-interviews.md
@@ -1,0 +1,84 @@
+# Project Research and Interviews
+
+## Background
+
+A key component to many of our projects is user research. We do this research at the beginning of most website projects and use it to inform what we build. Our user research has been done ad-hoc for a while, and recently we have started budgeting more time for it along with doing design work.
+
+The goal of this document is to describe our process as it exists today and use it as a starting point to improve and refine it over time.
+
+## Approach
+
+Project Research, Interviews & Design at DataMade are typically done in the following order:
+
+### 1. Scoping
+
+We only do user research for projects where we have explicitly included it in our scope. Here’s a recent example of what this language looks like from the [Risk & Reach project](https://github.com/datamade/risk-and-reach) for the Erikson Institute:
+
+> ### Research, stakeholder interviews and wireframes
+> DataMade will conduct a brief field scan of tools and reports showcasing data from other states’ Risk and Reach Reports to identify common patterns and best practices. DataMade will also conduct a series of short interviews of Erikson staff and target users to identify the most high priority goals.
+>
+> Once this research is complete, DataMade will develop a set of wireframes that will direct construction of the initial prototype (1.3).
+
+Note that this scope item includes research and wireframes in addition to stakeholder interviews. Often times, a report back on user research is also included (in the case of this example project, we did provide a report, though it wasn’t in the scope).
+
+### 2. Research
+
+As an initial step when conducting project design research is to familiarize ourselves with all relevant documents, resources and example websites. This research varies from project to project. For website redesign projects, it involves getting familiar with the existing website and its functionality. For new work, like the [Just Spaces project](https://github.com/datamade/just-spaces), the client has provided materials for us to read and review that inform the project.
+
+### 3. User interviews
+
+User research is typically followed next. It typically takes the most time to do, as well as client coordination, but is often the most informative.
+
+#### 1. Identify and connect with subjects for interview
+
+We typically interview 3-5 individuals with a variety of perspectives and interests as it pertains to the project. The client helps to identify these subjects and ideally will make an introduction to us to ensure they know who we are and what we are doing and why we’re doing it.
+
+It is important to interview each subject one at a time (pairs are fine if they are from the same organization or play the same role) as the answers they give will be much different than if they were being interviewed in a group setting.
+
+#### 2. Prepare interview questions
+
+Ahead of each interview, a set of interview questions are drafted. These questions can vary from subject to subject, but generally it is useful to ask all interviewees similar questions so you can identify common understandings as well as points of contention. These questions are shared ahead of time with each interviewee over email.
+
+Questions should be open-ended and never be satisfied with a simple yes or no.
+
+Examples:
+
+- How do you use the website? How often, and for how long?
+- What do you like about the website? What do you dislike?
+- What is a difficulty you have with the website?
+- What would you change?
+- What is the goal of this project, in your understanding?
+- What would you like this project to accomplish?
+- How do you see yourself using this website?
+
+If in person, try asking the interviewee to show you how they use the website. Note any workarounds they have in place, which buttons or sections they use, and the ease of how they navigate. Feel free to ask clarifying questions, but again keep them open-ended and non-judgemental. For example, “Why do you do it this way?” versus “Why don’t you do it this way?”
+
+#### 3. Conduct interview
+
+Interviews are typically 30 minutes or an hour. When possible, they are done in person and on-site. This allows additional observation about the environment that they work in. If an in-person meeting is not possible, a phone call is sufficient.
+
+Interviews should be conducted with two DataMade staff - one who leads the conversation, and the other who takes notes. The notes should include the date and time of the call, as well as a list of all attendees.
+
+Example: [Raw notes from our Risk & Reach interviews](https://docs.google.com/document/d/1WckPOJw7fY5wBl7dAYU3VaPW2u6e9QY_a1TjgsCM91M/edit?usp=sharing) (visible to DataMade employees only).
+
+Typically it takes 2-3 weeks to conduct the interviews. In some cases, additional users are identified as the interviews take place, which we typically interview as well.
+
+### 4. User Testing – Formal (optional)
+
+Formal user testing is rare among DataMade projects. Formal user testing involves coordinating a focus group where participants interact with a prototype. Usually members of the focus group are given a task to complete, and are observed. Formal user testing was done with the [Coordinated Entry Screening tool](https://github.com/datamade/coordinated-entry-screening), where we brought a prototype of the texting tool to the CSH offices and had individuals who had experienced homelessness interact with it.
+
+User testing is usually done in a group. Ideally no more than 3-5 individuals will be present at a given session. The client should recruit individuals in their network to participate in the focus group.
+
+We typically interview 3-5 individuals with a variety of perspectives and interests as it pertains to the project. The client helps to identify these subjects and ideally will make an introduction to us to ensure they know who we are and what we are doing and why we’re doing it.
+
+### 5. User Testing – Informal (typical)
+
+User testing is not always formally included in scopes. Informally, it is a part of the Agile iterative feedback loop.
+
+### 6. Reports
+
+Upon completion of a round of interviews DataMade prepares a report to share back with the client summarizing the high level points that we have taken away from the interviews. The goal of this report is not to reiterate their project and vision back to them, but to surface ideas, concerns and points of contention from the interviewees.
+
+Examples:
+- [Risk & Reach Website user research summary](https://docs.google.com/document/d/1Iu9JlsfLzxDQtmKpyG6WN9eMcKXu_sfp4h_eY__B_ak/edit?usp=sharing) (visible to DataMade employees only)
+- [Just Spaces User Research Report](https://docs.google.com/document/d/1XBhw7CJ7tJJ_XxCe3VLQ9ZAigZPFwLkvuvwSSnv8v94/edit?usp=sharing) (visible to DataMade employees only)


### PR DESCRIPTION
## Overview

Add a new folder for UX knowledge, and initialize it with the [Project Research and Interviews doc](https://docs.google.com/document/d/1NgmcCfBE3B9bTYF2TyTSY5m4QA6xLu2DxESeUTQYxUo/edit?usp=sharing).

Closes #14.

## Testing instructions

- View the Markdown preview of the new README: https://github.com/datamade/how-to/blob/feature/jfc/project-research-and-interviews/README.md
- View the preview of the new UX folder: https://github.com/datamade/how-to/tree/feature/jfc/project-research-and-interviews/ux
- View the preview of the new doc: https://github.com/datamade/how-to/blob/feature/jfc/project-research-and-interviews/ux/project-research-and-interviews.md