### PR TITLE
Change closes to handles in PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,7 +2,7 @@
 
 Brief description of what this PR does, and why it is needed.
 
-Closes #XXX
+Handles #XXX
 
 ### Demo
 


### PR DESCRIPTION
## Overview

This PR swaps "Closes" with "Handles" in the PR template. I made this change because we want issues to remain open for filing in our project board. We close them manually once a month.

## Testing Instructions

- View the rendered markdown on GitHub and confirm that it looks good and I spelled my one-word substitution correctly. ;-) 
