### PR TITLE
Add docs and recommendation of adoption for GitHub Actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ _In alphabetical order and including links to external repository-based document
 
 - [Amazon Web Services](aws/)
     - [AWS Relational Database Service (RDS)](aws/rds.md)
+- [Continuous Integration (CI)](ci/)
 - [Data processing and ETL](https://github.com/datamade/data-making-guidelines)
 - [Django](django/)
 - [Docker](docker/)

--- a/ci/README.md
+++ b/ci/README.md
@@ -1,0 +1,10 @@
+# Continuous Integration (CI)
+
+This directory records best practices for working with continuous integration (CI), external services that run builds and tests for us. 
+
+## Guides
+
+- [GitHub Actions: CI for apps deployed on Heroku or Netlify](./github-actions.md)
+- [Travis: Legacy CI for apps deployed on AWS EC2](./travis.md)
+- [Research](./research/)
+    - [Recommendation of adoption of GitHub Actions](./research/recommendation-of-adoption.md)

--- a/ci/README.md
+++ b/ci/README.md
@@ -5,6 +5,6 @@ This directory records best practices for working with continuous integration (C
 ## Guides
 
 - [GitHub Actions: CI for apps deployed on Heroku or Netlify](./github-actions.md)
-- [Travis: Legacy CI for apps deployed on AWS EC2](./travis.md)
+- [Travis: Legacy CI for apps deployed on AWS EC2](https://github.com/datamade/deploy-a-site/blob/master/Setup-deployment-hook.md#setup-codedeploy-hook-for-github--travis-ci)
 - [Research](./research/)
     - [Recommendation of adoption of GitHub Actions](./research/recommendation-of-adoption.md)

--- a/ci/README.md
+++ b/ci/README.md
@@ -1,6 +1,6 @@
 # Continuous Integration (CI)
 
-This directory records best practices for working with continuous integration (CI), external services that run builds and tests for us. 
+This directory records best practices for working with continuous integration (CI), external services that run builds and tests for us.
 
 ## Guides
 

--- a/ci/github-actions.md
+++ b/ci/github-actions.md
@@ -1,0 +1,125 @@
+# GitHub Actions
+
+This guide provides documentation for setting up continuous integration with [GitHub Actions](https://help.github.com/en/actions) for different types of projects.
+
+## Contents
+
+- [Running containerized tests](#running-containerized-tests)
+- [Deploying a Python package](#deploying-a-python-package)
+- [Resources](#resources)
+
+## Running containerized tests
+
+To initialize a workflow for running containerized tests, start by creating a new feature branch in your repo. Then, create a directory called `.github/workflows/` at the root of your repo. GitHub Actions will read any workflows from this directory and run them automatically.
+
+Next, define a file called `main.yml` in the workflows directory, and paste in the following configuration:
+
+```yaml
+name: CI
+
+on:
+  push:
+    branches:
+    - master
+  pull_request:
+    branches:
+    - master
+
+jobs:
+  test:
+    name: Run tests
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - name: Build containers and run tests
+      run: docker-compose -f docker-compose.yml -f tests/docker-compose.yml run --rm app
+```
+
+Commit this file to your feature branch and open up a pull request. You should be able to confirm that your workflow runs the tests for your pull request.
+
+### Examples
+
+This workflow is in use in the following projects:
+
+- [Minnesota Election Archive](https://github.com/datamade/mn-election-archive) (visible to DataMade developers only)
+
+## Deploying a Python package
+
+GitHub Actions can run arbitrary code, so we can use it to deploy Python packages to PyPI in addition to testing them.
+
+As above, start by making a new feature branch and creating the directory `.github/workflows/` at the root of your repo if it doesn't yet exist. Then, define two workflow files, one for each of the production and test PyPI instances:
+
+#### 📄`.github/workflows/publish-to-pypi.yml`
+
+```yaml
+name: Publish to PyPI
+
+on: push
+
+jobs:
+  build-and-publish:
+    name: Publish to PyPI
+    if: startsWith(github.event.ref, 'refs/tags')
+    runs-on: ubuntu-18.04
+    steps:
+    - uses: actions/checkout@master
+    - name: Set up Python 3.7
+      uses: actions/setup-python@v1
+      with:
+        python-version: 3.7
+    - name: Publish to PyPI
+      env:
+        TWINE_USERNAME: '__token__'
+        TWINE_PASSWORD: ${{ secrets.pypi_password }}
+      run: |
+        pip install twine wheel
+        pip wheel -w dist --no-deps .
+        twine upload --skip-existing dist/*
+      continue-on-error: true
+```
+
+#### 📄`.github/workflows/publish-to-test-pypi.yml`
+
+```yaml
+name: Publish to Test PyPI
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  build-and-publish:
+    name: Publish to Test PyPI
+    runs-on: ubuntu-18.04
+    steps:
+    - uses: actions/checkout@master
+    - name: Set up Python 3.7
+      uses: actions/setup-python@v1
+      with:
+        python-version: 3.7
+    - name: Publish to Test PyPI
+      env:
+        TWINE_USERNAME: '__token__'
+        TWINE_PASSWORD: ${{ secrets.test_pypi_password }}
+      run: |
+        pip install twine wheel
+        pip wheel -w dist --no-deps .
+        twine upload --skip-existing --repository-url https://test.pypi.org/legacy/ dist/*
+      continue-on-error: true
+```
+
+Next, follow the instructions for [creating encrypted secrets](https://help.github.com/en/actions/automating-your-workflow-with-github-actions/creating-and-using-encrypted-secrets#creating-encrypted-secrets) and save values for `pypi_password` and `test_pypi_password`.
+
+To test that this configuration works, you can alter the `on.push.branches` array of `publish-to-test-pypi.yml` to include the name of your feature branch, and you can push a test tag to your feature branch. Make sure to undo these two changes once you've confirmed that your configuration can properly deploy to PyPI and the test PyPI instance.
+
+### Examples
+
+Versions of this workflow are in use in the following packages:
+
+- [`django-geomultiplechoice`](https://github.com/datamade/django-geomultiplechoice/)
+- [`pytest-flask-sqlalchemy`](https://github.com/jeancochrane/pytest-flask-sqlalchemy) (no deployment to test PyPI, tests different versions of Python)
+
+## Resources
+
+For more detailed information on using GitHub Actions, refer to the [documentation](https://help.github.com/en/actions).

--- a/ci/github-actions.md
+++ b/ci/github-actions.md
@@ -35,6 +35,8 @@ jobs:
       run: docker-compose -f docker-compose.yml -f tests/docker-compose.yml run --rm app
 ```
 
+Due to the `on` block, this workflow will run the `test` job on all commits to `master` and all commits to pull requests that have been opened against `master`.
+
 Commit this file to your feature branch and open up a pull request. You should be able to confirm that your workflow runs the tests for your pull request.
 
 ### Examples
@@ -70,7 +72,7 @@ jobs:
     - name: Publish to PyPI
       env:
         TWINE_USERNAME: '__token__'
-        TWINE_PASSWORD: ${{ secrets.pypi_password }}
+        TWINE_PASSWORD: ${{ secrets.pypi_token }}
       run: |
         pip install twine wheel
         pip wheel -w dist --no-deps .
@@ -101,7 +103,7 @@ jobs:
     - name: Publish to Test PyPI
       env:
         TWINE_USERNAME: '__token__'
-        TWINE_PASSWORD: ${{ secrets.test_pypi_password }}
+        TWINE_PASSWORD: ${{ secrets.test_pypi_token }}
       run: |
         pip install twine wheel
         pip wheel -w dist --no-deps .
@@ -109,7 +111,9 @@ jobs:
       continue-on-error: true
 ```
 
-Next, follow the instructions for [creating encrypted secrets](https://help.github.com/en/actions/automating-your-workflow-with-github-actions/creating-and-using-encrypted-secrets#creating-encrypted-secrets) and save values for `pypi_password` and `test_pypi_password`.
+Taken together, these two workflows will publish any branch merged into `master` to [test PyPI](https://test.pypi.org/) and publish tagged commits to [PyPI](https://pypi.org/). This structure parallels our practice of keeping a staging site consistent with `master` and pushing tagged commits to production. If the active package version has already been deployed to either instance, the workflows will skip the upload to that instance; this means that only commits that bump the package version in `setup.py` will result in a newly deployed package.
+
+Next, follow the instructions for [creating encrypted secrets](https://help.github.com/en/actions/automating-your-workflow-with-github-actions/creating-and-using-encrypted-secrets#creating-encrypted-secrets) and save values for `pypi_token` and `test_pypi_token`.
 
 To test that this configuration works, you can alter the `on.push.branches` array of `publish-to-test-pypi.yml` to include the name of your feature branch, and you can push a test tag to your feature branch. Make sure to undo these two changes once you've confirmed that your configuration can properly deploy to PyPI and the test PyPI instance.
 
@@ -121,5 +125,7 @@ Versions of this workflow are in use in the following packages:
 - [`pytest-flask-sqlalchemy`](https://github.com/jeancochrane/pytest-flask-sqlalchemy) (no deployment to test PyPI, tests different versions of Python)
 
 ## Resources
+
+Our workflows for deploying Python packages to PyPI were adapted from the Python guide to [publishing package distribution releases using GitHub Actions](https://packaging.python.org/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows).
 
 For more detailed information on using GitHub Actions, refer to the [documentation](https://help.github.com/en/actions).

--- a/ci/research/recommendation-of-adoption.md
+++ b/ci/research/recommendation-of-adoption.md
@@ -1,0 +1,43 @@
+# Recommendation of adoption: GitHub Actions
+
+Based on our research, we recommend adopting GitHub Actions as our CI service of choice for **apps deployed on Heroku and Netlify**.
+
+For apps deployed on our legacy AWS EC2 infrastructure, we recommend sticking with Travis CI until a well-supported Action for working with CodeDeploy becomes available.
+
+The following document records our recommended path forward for adopting Gatsby.
+
+## Proof of concept
+
+As proof of concept, we tested GitHub Actions on a few different projects:
+
+- [`pytest-flask-sqlalchemy`](https://github.com/jeancochrane/pytest-flask-sqlalchemy/commit/b6b9f846977e7981a0ec69d969eceb99ddee58f7), a Python library deployed to PyPi
+- [`mn-election-archive`](https://github.com/datamade/mn-election-archive/pull/58), a Django app deployed on Heroku
+- [`document-search`](https://github.com/datamade/document-search/pull/28), a Django app deployed on AWS EC2 with CodeDeploy
+
+## Prerequisite skills
+
+GitHub Actions requires fluency in YAML, which is also required for Travis CI. It also requires that developers be familiar with the [workflow syntax for GitHub Actions](https://help.github.com/en/actions/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions), which is more flexible than Travis' language but has a steeper learning curve as a result.
+
+To deal with this learning curve, we aim to produce clear documentation and templates that developers can use to quickly bootstrap a GitHub Actions configuration.
+
+## Tradeoffs
+
+Advantages of GitHub Actions:
+
+- Native support for containerized deployments
+- Built in to our source control provider
+- Cheaper than Travis CI
+
+There are a few downsides to GitHub Actions:
+
+- No CodeDeploy integration
+- Workflow syntax is more complicated
+- No container layer caching
+
+Due to these tradeoffs, we think that GitHub Actions is an appropriate choice for apps that are not deployed with CodeDeploy. We will keep an eye out for CodeDeploy integrations, but until those arrive, we plan to continue supporting Travis CI for our legacy AWS EC2 infrastructure.
+
+## Maintenance outlook
+
+GitHub Actions is a low-risk choice of service because it is integrated with GitHub, the third-party service that we depend on the most. However, this adoption will create a situation for at least some amount of time where we have to maintain projects on two CI services, GitHub Actions and Travis, which could potentially make long-term maintenance tricky.
+
+This situation feels tenable because we have a substantial amount of written documentation for Travis CI along with a lot of developer expertise. We don't expect that existing Travis projects will be hard to maintain, even in a future where we're almost exclusively using GitHub Actions for new apps.

--- a/ci/research/recommendation-of-adoption.md
+++ b/ci/research/recommendation-of-adoption.md
@@ -4,7 +4,7 @@ Based on our research, we recommend adopting GitHub Actions as our CI service of
 
 For apps deployed on our legacy AWS EC2 infrastructure, we recommend sticking with Travis CI until a well-supported Action for working with CodeDeploy becomes available.
 
-The following document records our recommended path forward for adopting Gatsby.
+The following document records our recommended path forward for adopting GitHub Actions.
 
 ## Proof of concept
 


### PR DESCRIPTION
## Overview

This PR adds a recommendation of adoption for GitHub Actions, as well as some initial documentation for the service.

Connects #36. 

## Testing Instructions

* View the Markdown preview of the recommendation of adoption and Actions docs and confirm they look good
* Test new links and confirm that they work
* Confirm I haven't missed any `Contents` links in any READMEs
