### PR TITLE
Always set POSTGRES_PASSWORD in docker-compose.yml

### DIFF
--- a/docker/templates/python/{{cookiecutter.directory_name}}/docker-compose.yml
+++ b/docker/templates/python/{{cookiecutter.directory_name}}/docker-compose.yml
@@ -52,8 +52,8 @@ services:
       # that allow you to configure the container's behavior, without writing
       # any additional code. Specify the name of your database, and any other
       # variables, here. https://hub.docker.com/_/postgres/#environment-variables
-      - POSTGRES_DB={{cookiecutter.pg_db}}{% if cookiecutter.postgis == 'True' %}
-      - POSTGRES_PASSWORD=postgres{% endif %}
+      - POSTGRES_DB={{cookiecutter.pg_db}}
+      - POSTGRES_PASSWORD=postgres
     volumes:
       # By default, Postgres instantiates an anonymous volume. Use a named
       # one, so your data persists beyond the life of the container. See this


### PR DESCRIPTION
## Overview

GitHub Actions [always requires `POSTGRES_PASSWORD` be set](https://github.community/t5/GitHub-Actions/Services-name-resolution-error/m-p/37397/highlight/true#M2924) in order to run a Postgres service. This isn't necessarily well-documented, but it tripped me up and was difficult to debug, so I think we should consider always setting `POSTGRES_PASSWORD` in the config file here.

## Testing Instructions

* Not really sure if this needs detailed testing. I tested it in https://github.com/datamade/mn-election-archive/ and it worked well.
