### PR TITLE
Add guidance on managing secrets for local development

### DIFF
--- a/docker/local-development.md
+++ b/docker/local-development.md
@@ -33,8 +33,8 @@ some optional configurations and services:
 that declares the application and its dependent services
 3. [A `tests/docker-compose.yml` file](#3-testsdocker-composeyml)
 that overrides the application service in the root file, in order to run the tests
-4. [A `.env` file](#4-env-optional) that that sets secret values to be threaded
-into your app at runtime (Optional)
+4. [A `.env` file](#4-env-optional) that sets secret values to be threaded into
+your app at runtime (Optional)
 5. [A database initialization script](#5-scriptsinit-dbsh-optional)
 that creates your database and installs any extensions (Optional)
 6. [A `docker-compose.db-ops.yml` file](#6-docker-composedb-opsyml-optional)


### PR DESCRIPTION
## Overview

This PR adds a section on `.env` files to the documentation for local development with Docker. I included some reasons I like this approach in general. Here are some reasons I prefer this approach to Blackbox:

- GPG is tough to set up and use. Defining variables in a file and excluding that file from version control is not.
- We no longer use encrypted secrets in deployment settings, and we've broadly adopted LastPass as an alternative means of secrets management. It seems only natural to remove it from the equation for local development.

## Testing Instructions

* View the rendered markdown and confirm it looks good.
* Click the top navigation links and the external links in the new copy and confirm they resolve correctly.
