### PR TITLE
Add docs and update templates for Django-React integration

### DIFF
--- a/django/README.md
+++ b/django/README.md
@@ -11,6 +11,7 @@ In some cases, it also provides extended documentation for setup and use.
 | CMS | [`wagtail`](https://wagtail.io/developers/) | [Link](wagtail/README.md) |
 | Search | [`django-haystack`](https://github.com/django-haystack/django-haystack) | |
 | Autocomplete | [`django-autocomplete-light`](https://github.com/yourlabs/django-autocomplete-light) | |
-| Cross-browser ES6 support | [`django-compressor`](https://github.com/django-compressor/django-compressor) + [`django-compressor-toolkit`](https://github.com/kottenator/django-compressor-toolkit) | [Link](django-compressor.md) |
+| Cross-browser ES6 support | [`django-compressor`](https://github.com/django-compressor/django-compressor) | [Link](django-compressor.md) |
 | API | [`django-rest-framework`](https://github.com/encode/django-rest-framework) + [`django-cors-headers`](https://github.com/ottoyiu/django-cors-headers) | [Link](django-rest-framework.md) |
-| File uploads | [`django-storages`](https://django-storages.readthedocs.io/en/latest/) | [Link](file-uploads.md) | 
+| File uploads | [`django-storages`](https://django-storages.readthedocs.io/en/latest/) | [Link](file-uploads.md) |
+| React integration | [`django-compressor`](https://github.com/django-compressor/django-compressor) | [Link](django-react-integration.md) |

--- a/django/django-compressor.md
+++ b/django/django-compressor.md
@@ -1,5 +1,69 @@
 # django-compressor
 
-Pilot: https://github.com/datamade/bga-pensions/pull/1
+`django-compressor` is a library that provides Django utilities for compressing
+linked and inline JavaScript/CSS into a single cached file. At DataMade, we find
+it particularly useful for compiling ES6 and React to vanilla JavaScript that can
+run on a wide variety of browsers.
 
-_tk._
+Follow the steps below to set up `django-compressor` in your existing Django
+project, or use our [`new-django-app` Cookiecutter template](/docker/templates/)
+to create a new Django app with `django-compressor` already installed and configured
+for you.
+
+## Install Node packages
+
+Using `yarn add`, Update your `package.json` file to include
+the following list of Node packages:
+
+- `@babel/cli`
+- `@babel/core`
+- `@babel/preset-env`
+- `@babel/preset-react`
+- `babel-preset-env`
+- `babelify`
+- `browserify`
+
+## Install and configure `django-compressor`
+
+Update your `requirements.txt` file to install `django-compressor`. Then, set the
+following settings in `settings.py` to instruct it to bundle your React components:
+
+```python
+STATICFILES_FINDERS = (
+    'django.contrib.staticfiles.finders.FileSystemFinder',
+    'django.contrib.staticfiles.finders.AppDirectoriesFinder',
+    'compressor.finders.CompressorFinder',
+)
+
+COMPRESS_PRECOMPILERS = (
+    ('module', 'npx browserify {infile} -t [ babelify --presets [ @babel/preset-env ] ] > {outfile}'),
+    ('text/jsx', 'npx browserify {infile} -t [ babelify --presets [ @babel/preset-env @babel/preset-react ] ] > {outfile}'),
+)
+
+COMPRESS_OUTPUT_DIR = 'compressor'
+```
+
+## Set up caching
+
+The commands that bundle React components can take 2-3 seconds to complete, so
+make sure to set up [database caching](https://docs.djangoproject.com/en/3.0/topics/cache/#database-caching)
+and [cache your views that use React](https://docs.djangoproject.com/en/3.0/topics/cache/#the-per-view-cache)
+to make sure your pages load as quickly as possible.
+
+For an additional level of caching, you might also consider setting up
+[offline compression](https://django-compressor.readthedocs.io/en/stable/scenarios/#offline-compression)
+in `django-compressor`.
+
+## Use `django-compressor` in your templates
+
+For detailed examples on how to use `django-compressor` to compress and compile your
+JavaScript and CSS, see [the `django-compressor`
+documentation](https://django-compressor.readthedocs.io/en/stable/usage/).
+
+Note that `<script>` tags with a `type` value of `module` will be compiled as ES6
+code, while tags with a `type` value of `text/jsx` will be compiled as React code.
+
+## Further resources
+
+For an example of an app using `django-compressor` in production, see
+[BGA Pensions](https://github.com/datamade/bga-pensions/pull/1).

--- a/django/django-react-integration.md
+++ b/django/django-react-integration.md
@@ -1,0 +1,281 @@
+# Django-React Integration
+
+There are many ways of integrating Django and React. At DataMade, our preferred
+method is a so-called "hybrid" approach, where Django builds React components into its templates
+by using a context variable for props and bundling components with Babel, Browserify, and
+`django-compressor`. This allows a developer to opt-in to using React components
+in some templates, while still retaining the full expressive power of Django's
+templating system.
+
+## Contents
+- [Installation](#installation)
+    - [Install Node packages](#install-node-packages)
+    - [Install and configure `django-compressor`](#install-and-configure-django-compressor)
+    - [Set up caching](#set-up-caching)
+- [Usage](#usage)
+    - [Create a static JSX file for your React component](#create-a-static-jsx-file-for-your-react-component)
+    - [Define a view with a path to your component](#define-a-view-with-a-path-to-your-component)
+    - [Add a `props` key to your view context dictionary](#add-a-props-key-to-your-view-context-dictionary)
+    - [Create a Django template for your React component](#create-a-django-template-for-your-react-component)
+        - [Define a React root element](#define-a-react-root-element)
+        - [Set React props and root element on the `window` object](#set-react-props-and-root-element-on-the-window-object)
+        - [Bundle and load your component with `django-compressor`](#bundle-and-load-your-component-with-django-compressor)
+        - [Putting it all together](#putting-it-all-together)  
+- [Project fit considerations](#project-fit-considerations)
+- [Further reading](#further-reading)
+
+## Installation
+
+Setting up a hybrid Django-React application requires installing a number of
+Node packages, including Babel, Babelify, and Browserify, and then installing
+and configuring `django-compressor` to use these packages to bundle your
+React components.
+
+**Note**: If you're using our [`new-django-app` Cookiecutter template](/docker/templates/)
+to create your app, these installation steps will already be taken care of for you
+and you can skip ahead to [Usage](#usage).
+
+### Install Node packages
+
+Using `yarn add` or `npm install`, Update your `package.json` file to include
+the following list of Node packages:
+
+- `@babel/cli`
+- `@babel/core`
+- `@babel/preset-env`
+- `@babel/preset-react`
+- `babel-preset-env`
+- `babelify`
+- `browserify`
+
+### Install and configure `django-compressor`
+
+Update your `requirements.txt` file to install `django-compressor`. Then, set the
+following settings in `settings.py` to instruct it to bundle your React components:
+
+```python
+STATICFILES_FINDERS = (
+    'django.contrib.staticfiles.finders.FileSystemFinder',
+    'django.contrib.staticfiles.finders.AppDirectoriesFinder',
+    'compressor.finders.CompressorFinder',
+)
+
+COMPRESS_PRECOMPILERS = (
+    ('module', 'npx browserify {infile} -t [ babelify --presets [ @babel/preset-env ] ] > {outfile}'),
+    ('text/jsx', 'npx browserify {infile} -t [ babelify --presets [ @babel/preset-env @babel/preset-react ] ] > {outfile}'),
+)
+
+COMPRESS_OUTPUT_DIR = 'compressor'
+```
+
+### Set up caching
+
+The commands that bundle React components can take 2-3 seconds to complete, so
+make sure to set up [database caching](https://docs.djangoproject.com/en/3.0/topics/cache/#database-caching)
+and [cache your views that use React](https://docs.djangoproject.com/en/3.0/topics/cache/#the-per-view-cache)
+to make sure your pages load as quickly as possible.
+
+For an additional level of caching, you might also consider setting up
+[offline compression](https://django-compressor.readthedocs.io/en/stable/scenarios/#offline-compression)
+in `django-compressor`.
+
+## Usage
+
+Once your Django app is configured to bundle React components with `django-compressor`,
+you can bundle React components into your Django templates.
+
+Here are the steps for adding a React component to a template. The examples included
+in these steps are taken from the [`django-react-templates`
+repo](https://github.com/datamade/django-react-templates), which serves as a
+reference for this pattern.
+
+### Create a static JSX file for your React component
+
+In a dedicated static file directory, something like `static/js/pages`, create
+a file representing your React component.
+
+As an example, here's a simple component `index.js` that displays the name of a user:
+
+```jsx
+import React from 'react'
+import ReactDOM from 'react-dom'
+
+const Home = (props) => (
+  <>
+    <div className="container-fluid mb-1 jumbotron">
+      <div className="row">
+        <div className="col-sm-10 offset-sm-1">
+          <h1 className="mb-3">Django-React Integration</h1>
+        </div>
+      </div>
+    </div>
+    <div className="container">
+      <div className="row pt-5 pb-4 text-center">
+        <p>Welcome, {props.user}!</p>
+      </div>
+    </div>
+  </>
+)
+
+ReactDOM.render(
+  React.createElement(Home, window.props),
+  window.reactMount,
+)
+```
+
+Note that the component needs to be rendered with the `ReactDOM.render()` method,
+and should use the `window.props` object as its props. Later on when we define the
+Django template for this component, we'll make sure to save our props to this variable.
+
+### Define a view with a path to your component
+
+Define a Django view that includes a `component` attribute with a staticfile
+path to the component you've defined, as well as the typical `template_name`
+attribute representing the path to a Django template. The combination of these
+two attributes will allow us to render the component in the view's template.
+
+```python
+class Home(TemplateView):
+    title = 'Home'
+    template_name = 'example_app/index.html'
+    component = 'js/pages/index.js'  # Staticfile path to your component code
+```
+
+### Add a `props` key to your view context dictionary
+
+In the context dictionary for your view, add a `props` key representing the props
+that you want to pass into your React component. If you're using class-based views,
+you can update your context dictionary using the `get_context_data()` method.
+
+```python
+class Home(TemplateView):
+    title = 'Home'
+    template_name = 'example_app/index.html'
+    component = 'js/pages/index.js'  # Staticfile path to your component code
+
+    def get_context_data(self, *args, **kwargs):
+        context = super().get_context_data(*args, **kwargs)
+        context['props'] = {'user': 'foobar'}  # Set React props here
+        return context
+```
+
+### Create a Django template for your React component
+
+In order to render the React component we just defined, we need a Django template
+that can mark the component for bundling. Save this template to the path
+defined in your `template_name` view attribute.
+
+There are a few key components to this template. We'll consider them one by one.
+
+#### Define a React root element
+
+The template needs to have an element that React can use as a root to mount
+your component. For a better user experience, make sure to embed a loading animation
+like a spinner in this element so the user can see that your component is rendering.
+
+As an example, a simple root element might look like this:
+
+```html
+<div id="App">
+  <!-- Contents get replaced by mounted React.Component -->
+  <div class="text-center">
+    <i class="fa fa-lg fa-spinner fa-spin"></i><br><br>
+    <i class="pending">Loading components...</i><br><br>
+  </div>
+</div>
+```
+
+#### Set React props and root element on the `window` object
+
+In order to make your props and root element available to your React component, add
+a simple script to the end of your template to set them on the global `window`
+object.
+
+```html
+{{ props|json_script:"props" }}  // Serialize and safely sanitize the props
+<script type="text/javascript">
+  window.props = JSON.parse(document.getElementById('props').textContent)
+  window.reactMount = document.getElementById('App')
+</script>
+```
+
+#### Bundle and load your component with `django-compressor`
+
+Finally, use the `compress` templatetag provided by `django-compressor` and the
+`view.component` attribute to bundle and load your component as an external script.
+
+```html
+{% load compress %}
+{% compress js %}
+  <!-- The text/jsx type will trigger the COMPRESS_RECOMPILERS command specific to React -->
+  <script type="text/jsx" src="{% static view.component %}"></script>
+{% endcompress %}
+```
+
+#### Putting it all together
+
+With all of these components included, your template will look something like
+this:
+
+```html
+{% extends "example_app/base.html" %}
+{% load static %}
+
+{% block title %}{{ view.title }}{% endblock %}
+
+{% block body %}
+<div id="App">
+  <!-- Contents get replaced by mounted React.Component -->
+  <div class="text-center">
+    <i class="fa fa-lg fa-spinner fa-spin"></i><br><br>
+    <i class="pending">Loading components...</i><br><br>
+  </div>
+</div>
+{% endblock %}
+
+{% block extra_js %}
+{% load compress %}
+{{ props|json_script:"props" }}
+<script type="text/javascript">
+  window.props = JSON.parse(document.getElementById('props').textContent)
+  window.reactMount = document.getElementById('App')
+</script>
+{% compress js %}
+  <script type="text/jsx" src="{% static view.component %}"></script>
+  <script type="module" src="{% static 'js/base.js' %}"></script>
+{% endcompress %}
+{% endblock %}
+```
+
+Once you add your view to your app's URL patterns, you should be able to
+reload your app and view your rendered React component.
+
+## Project fit considerations
+
+Not all projects will be a good fit for the hybrid approach to Django-React integration.
+Projects that are a **good fit** will have the following characteristics:
+
+- A small, distinct set of pages that require a **high degree of interactivity**, in the context of
+  a larger app that is more straightforward (e.g. a data-management app with an interactive
+  data-driven map or dashboard)
+- Some degree of flexibility about **how fast the interactive pages load**, since hybrid
+  Django-React apps cannot be rendered on the server and so will have a brief extra loading
+  animation (e.g. a map that can load under a spinner animation)
+- Sufficient backend functionality that **a static app is not feasible** (e.g. an app
+  that requires user management)
+
+If your app does not have these characteristics, but a high degree of interactivity
+is still required, talk to a lead developer to discuss your options. There may
+be a way of factoring out certain portions of your app and deploying them as
+standalone [Gatsby apps](/gatsby).
+
+## Further reading
+
+This approach is heavily inspired by Nick Sweeting's blog post
+[How to build a frontend without making a Single-Page
+App](https://hackernoon.com/reconciling-djangos-mvc-templates-with-react-components-3aa986cf510a).
+If you'd like to get a better sense of the logic behind this pattern we strongly
+reccommend reading the post.
+
+For more background on the research that led us to adopt this approach, see
+[the corresponding R&D issue](https://github.com/datamade/how-to/issues/66).

--- a/django/django-react-integration.md
+++ b/django/django-react-integration.md
@@ -137,7 +137,7 @@ two attributes will allow us to render the component in the view's template.
 ```python
 class Home(TemplateView):
     title = 'Home'
-    template_name = 'example_app/index.html'
+    template_name = 'my_new_app/index.html'
     component = 'js/pages/index.js'  # Staticfile path to your component code
 ```
 
@@ -201,7 +201,7 @@ object.
 
 #### Bundle and load your component with `django-compressor`
 
-Finally, use the `compress` templatetag provided by `django-compressor` and the
+Finally, use the `compress` template tag provided by `django-compressor` and the
 `view.component` attribute to bundle and load your component as an external script.
 
 ```html

--- a/django/django-react-integration.md
+++ b/django/django-react-integration.md
@@ -177,8 +177,12 @@ object.
 
 #### Bundle and load your component with `django-compressor`
 
-Finally, use the `compress` template tag provided by `django-compressor` and the
-`view.component` attribute to bundle and load your component as an external script.
+Finally, use the `compress` template tag provided by `django-compressor` to bundle
+and load your component as an external script. Since we set a `component` attribute on
+our `View` class in the section ["Define a view with a path to your
+component"](#define-a-view-with-a-path-to-your-component) above, we can make use of the
+fact that Django automatically exposes a `view` variable in template context to
+access the path to our component using the variable `view.component`.
 
 ```html
 {% load compress %}

--- a/docker/templates/new-django-app/{{cookiecutter.app_name}}/package.json
+++ b/docker/templates/new-django-app/{{cookiecutter.app_name}}/package.json
@@ -3,9 +3,15 @@
   "version": "0.0.0",
   "description": "JavaScript development setup for {{cookiecutter.app_name}}",
   "dependencies": {
+    "@babel/cli": "^7.8.4",
+    "@babel/core": "^7.9.6",
+    "@babel/preset-env": "^7.9.6",
+    "@babel/preset-react": "^7.9.4",
     "babel-preset-env": "^1.7.0",
-    "babelify": "^7.3.0",
-    "browserify": "^16.5.0"
+    "babelify": "^10.0.0",
+    "browserify": "^16.5.0",
+    "react": "^16.13.1",
+    "react-dom": "^16.13.1"
   },
   "devDependencies": {}
 }

--- a/docker/templates/new-django-app/{{cookiecutter.app_name}}/requirements.txt
+++ b/docker/templates/new-django-app/{{cookiecutter.app_name}}/requirements.txt
@@ -5,7 +5,7 @@ psycopg2
 gunicorn
 dj-database-url
 whitenoise
-django-compressor-toolkit
+django-compressor
 sentry-sdk
 
 # Testing requirements

--- a/docker/templates/new-django-app/{{cookiecutter.app_name}}/{{cookiecutter.module_name}}/settings.py
+++ b/docker/templates/new-django-app/{{cookiecutter.app_name}}/{{cookiecutter.module_name}}/settings.py
@@ -50,7 +50,6 @@ INSTALLED_APPS = [
     'django.contrib.messages',
     'django.contrib.staticfiles',
     'compressor',
-    'compressor_toolkit',
     '{{cookiecutter.module_name}}'
 ]
 
@@ -155,16 +154,11 @@ STATICFILES_FINDERS = (
 
 # Django Compressor configs
 COMPRESS_PRECOMPILERS = (
-    ('module', 'compressor_toolkit.precompilers.ES6Compiler'),
+    ('module', 'npx browserify {infile} -t [ babelify --presets [ @babel/preset-env ] ] > {outfile}'),
+    ('text/jsx', 'npx browserify {infile} -t [ babelify --presets [ @babel/preset-env @babel/preset-react ] ] > {outfile}'),
 )
 
-COMPRESS_ES6_COMPILER_CMD = (
-    'export NODE_PATH="{paths}" && '
-    '{browserify_bin} "{infile}" -o "{outfile}" '
-    '-t [ "{node_modules}/babelify" --presets="{node_modules}/babel-preset-env" ]'
-)
-
-COMPRESS_OUTPUT_DIR =  'compressor'
+COMPRESS_OUTPUT_DIR = 'compressor'
 
 # Enforce SSL in production
 if DEBUG is False:


### PR DESCRIPTION
## Overview

This PR adds documentation and updates the `new-django-app` template to recommend a pattern for using React components in a Django app.

Connects #66.

## Testing Instructions

* View the rendered markdown, confirm it looks good and links resolve properly
* Change to the `docker/templates` directory and create a new app with `docker-compose run --rm cookiecutter -f new-django-app`
* Accept all default Cookiecutter options
* Change to the `my-new-app` repo and build container images with `docker-compose build`
* Follow the instructions in the `Usage` section of the new docs and use the example code to test the hybrid integration
* Visit http://localhost:8000 and confirm you see the text `Welcome, foobar!` below
* Once you're done testing, remember to clean up the testing app:
    * `docker-compose down --volumes`
    * `cd ../ && rm -Rf my-new-app`
    * `docker rmi my-new-app`
