### PR TITLE
Update Sentry-Slack docs to match new integration

### DIFF
--- a/logging/slack.md
+++ b/logging/slack.md
@@ -20,6 +20,7 @@ On the "New Alert" page, choose to create an "Issue Alert", and configure
 rule conditions to send a notification whenever the condition `An event is seen`
 is met. Add an action to send a Slack message to the `DataMade` workspace with
 the slug of your channel, and optionally include `environment` or `user` in your tags.
+
 Hit `Save rule` and test to make sure your rule sends a Slack notification (the
 [Django integration docs](https://docs.sentry.io/platforms/python/django/) provide
 an example of how to perform this kind of test).

--- a/logging/slack.md
+++ b/logging/slack.md
@@ -13,12 +13,16 @@ notifications to Slack, DataMade's preferred business chat service.
 ## Push Sentry notifications to Slack
 
 Once you've [added your project to Sentry](./sentry.md), optionally configure
-Sentry to forward exceptions to Slack. From the Sentry dashboard, click Settings,
-then Integrations. Find the Slack integration in the list, and click "Configure."
+Sentry to forward exceptions to Slack. Navigate to the Settings dashboard for
+your project, choose "Alerts" in the sidebar, and select "New alert rule".
 
-You'll be taken to a list of all DataMade projects in Sentry. Find yours, then
-click "Add Alert Rule" and configure the alert you'd like to send. Usually,
-we forward all messages in Sentry to the project Slack channel.
+On the "New Alert" page, choose to create an "Issue Alert", and configure
+rule conditions to send a notification whenever the condition `An event is seen`
+is met. Add an action to send a Slack message to the `DataMade` workspace with
+the slug of your channel, and optionally include `environment` or `user` in your tags.
+Hit `Save rule` and test to make sure your rule sends a Slack notification (the
+[Django integration docs](https://docs.sentry.io/platforms/python/django/) provide
+an example of how to perform this kind of test).
 
 ## Push Netlify notifications to Slack
 


### PR DESCRIPTION
## Overview

Sentry's new Slack app changes the interface for configuring Slack integrations. This PR updates our docs to match that change.

## Testing Instructions

* View the rendered markdown and confirm it looks good
* Navigate to the Settings dashboard in Sentry and confirm that the instructions accurately describe the interface