### PR TITLE
Don't automatically restart app containers

### DIFF
--- a/docker/templates/new-django-app/{{cookiecutter.app_name}}/docker-compose.yml
+++ b/docker/templates/new-django-app/{{cookiecutter.app_name}}/docker-compose.yml
@@ -4,7 +4,6 @@ services:
   app:
     image: {{cookiecutter.app_name}}
     container_name: {{cookiecutter.app_name}}
-    restart: always
     build: .
     # Allow container to be attached to, e.g., to access the pdb shell
     stdin_open: true

--- a/docker/templates/python-docker-env/{{cookiecutter.directory_name}}/docker-compose.yml
+++ b/docker/templates/python-docker-env/{{cookiecutter.directory_name}}/docker-compose.yml
@@ -4,7 +4,6 @@ services:
   app:
     image: {{cookiecutter.app_name}}
     container_name: {{cookiecutter.app_name}}
-    restart: always
     build: .
     # Allow container to be attached to, e.g., to access the pdb shell
     stdin_open: true


### PR DESCRIPTION
## Overview

I don't fully understand why we set app containers to automatically restart in development, and it has the annoying side effect of causing random apps to start up when I start up Docker. This PR proposes removing this setting from the `new-django-app` and `python-docker-env` environments.

## Testing Instructions

* Confirm the change is reasonable
