### PR TITLE
Fix PostGIS support in new-django-app template

### DIFF
--- a/docker/templates/new-django-app/{{cookiecutter.app_name}}/Dockerfile
+++ b/docker/templates/new-django-app/{{cookiecutter.app_name}}/Dockerfile
@@ -22,7 +22,7 @@ RUN curl -sL https://deb.nodesource.com/setup_12.x | bash -
 #
 # Read more on Dockerfile best practices at the source:
 # https://docs.docker.com/develop/develop-images/dockerfile_best-practices
-RUN apt-get install -y --no-install-recommends postgresql-client nodejs
+RUN apt-get install -y --no-install-recommends postgresql-client nodejs{% if cookiecutter.postgis == 'True' %} gdal-bin{% endif %}
 
 # Inside the container, create an app directory and switch into it
 RUN mkdir /app

--- a/docker/templates/new-django-app/{{cookiecutter.app_name}}/{{cookiecutter.module_name}}/settings.py
+++ b/docker/templates/new-django-app/{{cookiecutter.app_name}}/{{cookiecutter.module_name}}/settings.py
@@ -92,7 +92,8 @@ DATABASES = {}
 DATABASES['default'] = dj_database_url.parse(
     os.getenv('DATABASE_URL', 'postgres://postgres:postgres@postgres:5432/{{cookiecutter.pg_db}}'),
     conn_max_age=600,
-    ssl_require=True if os.getenv('POSTGRES_REQUIRE_SSL') else False
+    ssl_require=True if os.getenv('POSTGRES_REQUIRE_SSL') else False{% if cookiecutter.postgis == 'True' %},
+    engine='django.contrib.gis.db.backends.postgis'{% endif %}
 )
 
 # Caching


### PR DESCRIPTION
## Overview

Update the `Dockerfile` and `settings.py` files in the `new-django-app` template to properly install GDAL and set the Django engine to support PostGIS as a backend when `postgis` is `True`.

Handles #93.

## Testing Instructions

* Change into the `docker/templates/` directory
* Run `docker-compose run --rm cookiecutter -f new-django-app`
* Accept all default settings, but set `postgis` to `True`
* Change into `my-new-app/` and run `docker-compose up --build`
* Confirm that the app builds properly and is visible on http://localhost:8000
* Shut down the app with `docker-compose down --volumes`
* Change back to the `docker/templates/` directory and remove the new app with `rm -RF my-new-app`
* Remove old image with `docker rmi my-new-app`
* Create a new app **without** PostGIS support by running `docker-compose run --rm cookiecutter -f new-django-app` again
* Confirm that the `Dockerfile` and `settings.py` files look syntactically correct
