### PR TITLE
Specify NODE_PATH so locally installed packages can be found

### DIFF
--- a/docker/templates/new-django-app/{{cookiecutter.app_name}}/{{cookiecutter.module_name}}/settings.py
+++ b/docker/templates/new-django-app/{{cookiecutter.app_name}}/{{cookiecutter.module_name}}/settings.py
@@ -155,8 +155,8 @@ STATICFILES_FINDERS = (
 
 # Django Compressor configs
 COMPRESS_PRECOMPILERS = (
-    ('module', 'npx browserify {infile} -t [ babelify --presets [ @babel/preset-env ] ] > {outfile}'),
-    ('text/jsx', 'npx browserify {infile} -t [ babelify --presets [ @babel/preset-env @babel/preset-react ] ] > {outfile}'),
+    ('module', 'export NODE_PATH=/app/node_modules && npx browserify {infile} -t [ babelify --presets [ @babel/preset-env ] ] > {outfile}'),
+    ('text/jsx', 'export NODE_PATH=/app/node_modules && npx browserify {infile} -t [ babelify --presets [ @babel/preset-env @babel/preset-react ] ] > {outfile}'),
 )
 
 COMPRESS_OUTPUT_DIR = 'compressor'


### PR DESCRIPTION
## Overview

See title. This change is necessary because tests otherwise fail when hitting routes that return templates containing compressed JavaScript. See: https://github.com/datamade/california-dream-index/pull/49

## Testing Instructions

* Repeat the testing instructions from https://github.com/datamade/how-to/pull/84.
