### PR TITLE
Gatsby plugin docs (Sentry & Recharts)

### DIFF
--- a/docker/templates/new-gatsby-app/{{cookiecutter.app_name}}/gatsby-config.js
+++ b/docker/templates/new-gatsby-app/{{cookiecutter.app_name}}/gatsby-config.js
@@ -36,5 +36,11 @@ module.exports = {
         trackingId: "",
       },
     },
+    {
+      resolve: "@sentry/gatsby",
+      options: {
+        dsn: process.env.SENTRY_DSN ? process.env.SENTRY_DSN : "",
+      }
+    },
   ],
 }

--- a/docker/templates/new-gatsby-app/{{cookiecutter.app_name}}/package.json
+++ b/docker/templates/new-gatsby-app/{{cookiecutter.app_name}}/package.json
@@ -5,6 +5,7 @@
   "version": "0.1.0",
   "author": "DataMade",
   "dependencies": {
+    "@sentry/gatsby": "^5.27.3",
     "bootstrap": "^4.4.1",
     "eslint-config-react-app": "^5.2.1",
     "gatsby": "^2.19.45",

--- a/docker/templates/new-gatsby-app/{{cookiecutter.app_name}}/yarn.lock
+++ b/docker/templates/new-gatsby-app/{{cookiecutter.app_name}}/yarn.lock
@@ -1739,6 +1739,89 @@
     lodash "^4.17.15"
     lodash-es "^4.17.15"
 
+"@sentry/browser@5.27.3":
+  version "5.27.3"
+  resolved "https://registry.yarnpkg.com/@sentry/browser/-/browser-5.27.3.tgz#02e78a4502ee99988d3cbb0075a11ec44b503871"
+  integrity sha512-vczS+XTW4Nk2A7TIpAw8IVFHpp+NK6mV9euBG2I61Bs2QbQY9yKLfbjiln/yH2Q8X4THX6MKa0GuiPoCEeq3uw==
+  dependencies:
+    "@sentry/core" "5.27.3"
+    "@sentry/types" "5.27.3"
+    "@sentry/utils" "5.27.3"
+    tslib "^1.9.3"
+
+"@sentry/core@5.27.3":
+  version "5.27.3"
+  resolved "https://registry.yarnpkg.com/@sentry/core/-/core-5.27.3.tgz#d7a175b71596b7eb4b2e8b4cd1858a60d95813bb"
+  integrity sha512-yqepQO88jSt5hy0awpk61AxI4oHB09LjVbUEk4nJDg+1YXuND23cuZvH+Sp2jCZX2vrsw2tefwflToYfA8/U2w==
+  dependencies:
+    "@sentry/hub" "5.27.3"
+    "@sentry/minimal" "5.27.3"
+    "@sentry/types" "5.27.3"
+    "@sentry/utils" "5.27.3"
+    tslib "^1.9.3"
+
+"@sentry/gatsby@^5.27.3":
+  version "5.27.3"
+  resolved "https://registry.yarnpkg.com/@sentry/gatsby/-/gatsby-5.27.3.tgz#6688e2615667ad710a53e85f3a7456936bc2c482"
+  integrity sha512-iMEqXOax0Q7xH/enk4bJFGknzBF0e0S6GtamffOHEw6PcyDgHSF9Pwx2nUXM74zZ2N1Ek2SnKbsMUdXR7jlAzA==
+  dependencies:
+    "@sentry/react" "5.27.3"
+    "@sentry/tracing" "5.27.3"
+
+"@sentry/hub@5.27.3":
+  version "5.27.3"
+  resolved "https://registry.yarnpkg.com/@sentry/hub/-/hub-5.27.3.tgz#f509c2fd38f500afef6030504e82510dbd0649d6"
+  integrity sha512-icEH3hr6NVQkpowXZcPOs9IgJZP5lMKtvud4mVioSpkd+NxtRdKrGEX4eF2TCviOJc9Md0mV4K+aL5Au7hxggQ==
+  dependencies:
+    "@sentry/types" "5.27.3"
+    "@sentry/utils" "5.27.3"
+    tslib "^1.9.3"
+
+"@sentry/minimal@5.27.3":
+  version "5.27.3"
+  resolved "https://registry.yarnpkg.com/@sentry/minimal/-/minimal-5.27.3.tgz#c9263bdd6270bfeae64137177448911dff568e53"
+  integrity sha512-ng01cM0rsE1RMjqVTpPLN0ZVkTo0I675usM1krkpQe8ddW6tfQ6EJWpt02/BrpQZRQzTtfWp6/RyB1KFXg6icg==
+  dependencies:
+    "@sentry/hub" "5.27.3"
+    "@sentry/types" "5.27.3"
+    tslib "^1.9.3"
+
+"@sentry/react@5.27.3":
+  version "5.27.3"
+  resolved "https://registry.yarnpkg.com/@sentry/react/-/react-5.27.3.tgz#aefff1cb2249a4e7f123c7467d1da205d5c02e92"
+  integrity sha512-p7E+djSUVKz02HoRVDX+zamjV8+RL4bqoPnS9JQESweB0sRTYlpvi+CqWLYWNWnamWQWOl97hOw/lLDpo4kUSA==
+  dependencies:
+    "@sentry/browser" "5.27.3"
+    "@sentry/minimal" "5.27.3"
+    "@sentry/types" "5.27.3"
+    "@sentry/utils" "5.27.3"
+    hoist-non-react-statics "^3.3.2"
+    tslib "^1.9.3"
+
+"@sentry/tracing@5.27.3":
+  version "5.27.3"
+  resolved "https://registry.yarnpkg.com/@sentry/tracing/-/tracing-5.27.3.tgz#787e57a2f7071e375f4fad0f3c3a5ff3381928e7"
+  integrity sha512-UWrHMdGxPfx1u558CWm1tptc2z0BuqCHVe2+BNN7POahq5BkpbGqaotyPQTBHbfmcs6QGfsMG57ou8HQFrBxyA==
+  dependencies:
+    "@sentry/hub" "5.27.3"
+    "@sentry/minimal" "5.27.3"
+    "@sentry/types" "5.27.3"
+    "@sentry/utils" "5.27.3"
+    tslib "^1.9.3"
+
+"@sentry/types@5.27.3":
+  version "5.27.3"
+  resolved "https://registry.yarnpkg.com/@sentry/types/-/types-5.27.3.tgz#d377508769bc658d672c287166c7f6c5db45660c"
+  integrity sha512-PkWhMArFMxBb1g3HtMEL8Ea9PYae2MU0z9CMIWiqzerFy2ZpKG98IU3pt8ic4JkmKQdwB8hDiZpRPMHhW0WYwQ==
+
+"@sentry/utils@5.27.3":
+  version "5.27.3"
+  resolved "https://registry.yarnpkg.com/@sentry/utils/-/utils-5.27.3.tgz#1fc45dfad1f1e4398bee58684d8947666d8d3003"
+  integrity sha512-R9WvFrRBALZvCzu/9BsuXBCfkNxz4MwdBNSXaBsJo4afQw1ljkjIc9DpHzlL9S9goIwXo81Buwmr5gGDO6aH+Q==
+  dependencies:
+    "@sentry/types" "5.27.3"
+    tslib "^1.9.3"
+
 "@sindresorhus/is@^0.14.0":
   version "0.14.0"
   resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-0.14.0.tgz#9fb3a3cf3132328151f353de4632e01e52102bea"
@@ -7362,7 +7445,7 @@ hmac-drbg@^1.0.0:
     minimalistic-assert "^1.0.0"
     minimalistic-crypto-utils "^1.0.1"
 
-hoist-non-react-statics@^3.3.0:
+hoist-non-react-statics@^3.3.0, hoist-non-react-statics@^3.3.2:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz#ece0acaf71d62c2969c2ec59feff42a4b1a85b45"
   integrity sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==

--- a/gatsby/README.md
+++ b/gatsby/README.md
@@ -20,6 +20,13 @@ This directory records best practices for working with [GatsbyJS](https://github
     - [Some example setups](stack.md#some-example-setups)
     - [Managing packages and plugins](stack.md#managing-packages-and-plugins)
 
+## Standard toolkit
+
+| Objective | Library | Internal documentation |
+| :- | :- | :- |
+| Data Visualization | [`recharts`](http://recharts.org/) | |
+| Error Logging | [`@sentry/gatsby`](https://www.gatsbyjs.com/plugins/@sentry/gatsby/) | [Link](./../logging/sentry.md#logging-errors-in-gatsby-applications) |
+
 ## When to use Gatsby
 
 Gatsby is an excellent choice for two types of projects:

--- a/gatsby/recharts.md
+++ b/gatsby/recharts.md
@@ -1,0 +1,15 @@
+# recharts
+
+[`recharts`](http://recharts.org/) is a charting library for React components and our preferred method to create data visualizations in Gatsby projects. Install it in your containerized Gatsby project by running:
+
+`docker-compose run --rm add recharts --save`
+
+You can then import components that you want to use into individual modules. See [Getting Started](http://recharts.org/en-US/guide/getting-started) and the [Examples page](http://recharts.org/en-US/examples) for models of how this works.
+
+In general, Recharts is a robust library but often underdocumented. We recommend starting from their examples page to build what you want, then consulting StackOverflow as you hit the limits of what the official documentation can offer.
+
+## On data transformation
+**We do _not_ recommend performing any data transformation with Recharts or in frontend Gatsby components.** This can slow down an application's performance as calculations run on page load, and also creates an unnecessary opportunity for error in a project's data pipeline. Instead, all data transformation for visualizations should be performed in separate scripts that generate finalized data that can then be passed directly to Recharts components. A couple example setups for this:
+
+- For [The Circuit's charges visualizations](https://gitlab.com/court-transparency-project/charges-app), we ran a remote database using Amazon RDS. This database had an `analysis` schema with tables created with raw SQL commands run by a Makefile in a [separate data repo](https://gitlab.com/court-transparency-project/cleaning-charges). These tables were formatted to pass directly to Recharts via GraphQL queries with a [Hasura](https://hasura.io/) connection.
+- For Gatsby projects with smaller data sets that can be kept under version control, we recommend following [DataMade's datamaking practices](https://github.com/datamade/data-making-guidelines) and transforming data with Python scripts via a Makefile. Recharts can then source directly from the `data/finalized` directory. Bea's [Covid-19 Neighborhoods](https://github.com/beamalsky/medical-examiner-data) website is an example of this approach.

--- a/logging/sentry.md
+++ b/logging/sentry.md
@@ -180,6 +180,12 @@ a Sentry hook:
 Now, all 400 errors should be grouped under the same issue in Sentry. Proceed to
 the Sentry dashboard and ignore these errors as needed.
 
-## Logging errors in Django applications
+## Logging errors in Gatsby applications
 
-We log errors in Gatsby applications using [`@sentry/gatsby`](https://www.gatsbyjs.com/plugins/@sentry/gatsby/), which is the official SDK and a wrapper around the `@sentry/react` package. Installation instructions and option documentation can be found [here](https://www.gatsbyjs.com/plugins/@sentry/gatsby/), and [this blog post about how it works](https://cra.mr/instrumenting-gatsbyjs-with-sentry/) is helpful for understanding what's going on under the hood.
+There are several Gatsby plugins for Sentry integrations, but we prefer [`@sentry/gatsby`](https://www.gatsbyjs.com/plugins/@sentry/gatsby/) because it is the official Sentry SDK for Gatsby and allows for a setup very similar to Django projects.
+
+First, create a new Sentry project following the steps above and generate a DSN. Once you have that value, add it to your local `.env ` file and Netlify environment as `SENTRY_DSN`.
+
+Then you just need to install the `@sentry/gatsby` package and point it toward that DSN value—those setup instructions and option documentation can be found [here](https://www.gatsbyjs.com/plugins/@sentry/gatsby/).
+
+For further reading about how `@sentry/gatsby` works under the hood, [this blog post is useful](https://cra.mr/instrumenting-gatsbyjs-with-sentry/).

--- a/logging/sentry.md
+++ b/logging/sentry.md
@@ -16,6 +16,7 @@ This document describes how to configure your applications to log errors to
         - [Thread the DSN into the app environment](#thread-the-dsn-into-the-app-environment)
         - [Initialize `sentry_sdk` in `settings.py`](#initialize-sentrysdk-in-settingspy)
         - [Group 400 errors](#group-400-errors)
+- [Logging errors in Gatsby applications](#logging-errors-in-gatsby-applications)
 
 ## Background
 
@@ -178,3 +179,7 @@ a Sentry hook:
 
 Now, all 400 errors should be grouped under the same issue in Sentry. Proceed to
 the Sentry dashboard and ignore these errors as needed.
+
+## Logging errors in Django applications
+
+We log errors in Gatsby applications using [`@sentry/gatsby`](https://www.gatsbyjs.com/plugins/@sentry/gatsby/), which is the official SDK and a wrapper around the `@sentry/react` package. Installation instructions and option documentation can be found [here](https://www.gatsbyjs.com/plugins/@sentry/gatsby/), and [this blog post about how it works](https://cra.mr/instrumenting-gatsbyjs-with-sentry/) is helpful for understanding what's going on under the hood.

--- a/logging/sentry.md
+++ b/logging/sentry.md
@@ -186,6 +186,6 @@ There are several Gatsby plugins for Sentry integrations, but we prefer [`@sentr
 
 First, create a new Sentry project following the steps above and generate a DSN. Once you have that value, add it to your local `.env ` file and Netlify environment as `SENTRY_DSN`.
 
-Then you just need to install the `@sentry/gatsby` package and point it toward that DSN value—those setup instructions and option documentation can be found [here](https://www.gatsbyjs.com/plugins/@sentry/gatsby/).
+Then you just need to install the `@sentry/gatsby` package (this is done by default in our [Gatsby cookiecutter template]((/docker/templates/))) and point it toward that DSN value—those setup instructions and option documentation can be found [here](https://www.gatsbyjs.com/plugins/@sentry/gatsby/).
 
 For further reading about how `@sentry/gatsby` works under the hood, [this blog post is useful](https://cra.mr/instrumenting-gatsbyjs-with-sentry/).


### PR DESCRIPTION
## Overview

The PR adds documentation for using Sentry and Recharts in Gatsby.

Closes #127. 
Closes #72.

## Testing Instructions

* Read through the new pages and edit for clarity, completeness, and working links.
* I considered adding Sentry to the Gatsby template instead, but it felt wrong to install it as a dependency before a project has a DSN string. Check that assumption for me.
