### PR TITLE
Add recommendation of adoption for GH Actions / CodeDeploy

### DIFF
--- a/ci/README.md
+++ b/ci/README.md
@@ -4,7 +4,7 @@ This directory records best practices for working with continuous integration (C
 
 ## Guides
 
-- [GitHub Actions: CI for apps deployed on Heroku or Netlify](./github-actions.md)
-- [Travis: Legacy CI for apps deployed on AWS EC2](https://github.com/datamade/deploy-a-site/blob/master/Setup-deployment-hook.md#setup-codedeploy-hook-for-github--travis-ci)
+- [GitHub Actions](./github-actions.md)
 - [Research](./research/)
     - [Recommendation of adoption of GitHub Actions](./research/recommendation-of-adoption.md)
+    - [Amendment 1](./research/amendment-1.md): Recommendation of adoption for CodeDeploy integration with GitHub Actions

--- a/ci/github-actions.md
+++ b/ci/github-actions.md
@@ -6,9 +6,12 @@ This guide provides documentation for setting up continuous integration with [Gi
 
 - [Running containerized tests](#running-containerized-tests)
 - [Deploying a Python package](#deploying-a-python-package)
+- [Deploying a legacy application to CodeDeploy](#deploying-a-legacy-application-to-codedeploy)
 - [Resources](#resources)
 
 ## Running containerized tests
+
+N.b., we recommend running containerized tests when the application is containerized in deployment, i.e., deployed to Netlify. For legacy applications deployed on AWS EC2 infrastructure, we recommend a service-based test run. [Skip to deploying a legacy application to CodeDeploy](#deploying-a-legacy-application-to-codedeploy) for an example of this pattern.
 
 To initialize a workflow for running containerized tests, start by creating a new feature branch in your repo. Then, create a directory called `.github/workflows/` at the root of your repo. GitHub Actions will read any workflows from this directory and run them automatically.
 
@@ -125,8 +128,107 @@ Versions of this workflow are in use in the following packages:
 - [`django-geomultiplechoice`](https://github.com/datamade/django-geomultiplechoice/)
 - [`pytest-flask-sqlalchemy`](https://github.com/jeancochrane/pytest-flask-sqlalchemy) (no deployment to test PyPI, tests different versions of Python)
 
+## Deploying a legacy application to CodeDeploy
+
+As above, start by making a new feature branch and creating the directory `.github/workflows/` at the root of your repo if it doesn't yet exist. Then, define a workflow file:
+
+#### 📄`.github/workflows/main.yml`
+
+```yaml
+name: CI
+
+on:
+  push:
+    branches:
+      - master
+      - deploy
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  test:
+    name: Run tests
+    runs-on: ubuntu-latest
+    services:
+      # 🚨 Update the Postgres version and database name to match your app environment and test config
+      postgres:
+        image: postgres:${POSTGRES_VERSION}
+        env:
+          POSTGRES_DB: ${POSTGRES_DATABASE}
+          POSTGRES_PASSWORD: postgres
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 5432:5432
+    steps:
+    - uses: actions/checkout@v2
+    # 🚨 Update the Python version to match your app environment
+    - name: Set up Python ${PYTHON_VERSION}
+      uses: actions/setup-python@v2
+      with:
+        # Semantic version range syntax or exact version of a Python version
+        python-version: '${PYTHON_VERSION}'
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
+    - name: Test with pytest
+      # 🚨 Swap in the correct filenames for your test and application configs
+      run: |
+        mv ${TEST_CONFIG} ${APP_CONFIG}
+        pytest -sv
+  deploy:
+    needs: test
+    name: Deploy to AWS
+    runs-on: ubuntu-latest
+    steps:
+      - uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-east-1
+      - uses: actions/checkout@v2
+      - id: deploy
+        uses: webfactory/create-aws-codedeploy-deployment@0.2.2
+        with:
+          # 🚨 Swap in your CodeDeploy application name, which is usually the same as the repository name
+          application: ${CODEDEPLOY_APPLICATION_NAME}
+```
+
+Update the values indicated inline with the 🚨 emoji. Then, append the following to `.appspec.yml`.
+
+#### 📄`.appspec.yml`
+
+```yaml
+# ... deployment lifecycle config ...
+branch_config:
+  master:
+    deploymentGroupName: staging
+  deploy:
+    deploymentGroupName: production
+```
+
+This workflow runs your tests, then creates a deployment conditional on your tests passing. The `deploy` action determines which deployment group, if any, it should create a deployment for using the `branch_config` you added to `.appspec.yml`. In effect, commits to `master` are deployed to staging and commits to `deploy` are deployed to production; commits to all other branches result in a no-op.
+
+Next, follow the instructions for [creating encrypted secrets](https://help.github.com/en/actions/automating-your-workflow-with-github-actions/creating-and-using-encrypted-secrets#creating-encrypted-secrets) and save values for `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`, using the developer credentials in our team LastPass.
+
+To test that this configuration works, you can update the `on.push.branches` array of `main.yml` to include the name of your feature branch, and point your branch to the staging deployment group in the `branch_config` block of `.appspec.yml`. The result should be a staging deployment of your app on the next commit to your branch. Don't forget to revert these changes once you've tested the integration.
+
+### Examples
+
+This workflow is in use in the following applications:
+
+- [`la-metro-councilmatic`](https://github.com/datamade/la-metro-councilmatic)
+- [`la-metro-dashboard`](https://github.com/datamade/la-metro-dashboard)
+
 ## Resources
 
 Our workflows for deploying Python packages to PyPI were adapted from the Python guide to [publishing package distribution releases using GitHub Actions](https://packaging.python.org/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows).
+
+Our workflow for deploying to CodeDeploy via GitHub Actions comes from [Webfactory's `create-aws-codedeploy-deployment` action](https://github.com/marketplace/actions/webfactory-create-aws-codedeploy-deployment), which includes further details on configuration and usage.
 
 For more detailed information on using GitHub Actions, refer to the [documentation](https://help.github.com/en/actions).

--- a/ci/github-actions.md
+++ b/ci/github-actions.md
@@ -11,7 +11,7 @@ This guide provides documentation for setting up continuous integration with [Gi
 
 ## Running containerized tests
 
-N.b., we recommend running containerized tests when the application is containerized in deployment, i.e., deployed to Netlify. For legacy applications deployed on AWS EC2 infrastructure, we recommend a service-based test run. [Skip to deploying a legacy application to CodeDeploy](#deploying-a-legacy-application-to-codedeploy) for an example of this pattern.
+N.b., we recommend running containerized tests when the application is containerized in deployment, i.e., deployed to Heroku. For legacy applications deployed on AWS EC2 infrastructure, we recommend a service-based test run. [Skip to deploying a legacy application to CodeDeploy](#deploying-a-legacy-application-to-codedeploy) for an example of this pattern.
 
 To initialize a workflow for running containerized tests, start by creating a new feature branch in your repo. Then, create a directory called `.github/workflows/` at the root of your repo. GitHub Actions will read any workflows from this directory and run them automatically.
 

--- a/ci/research/amendment-1.md
+++ b/ci/research/amendment-1.md
@@ -1,0 +1,67 @@
+# Recommendation of adoption: CodeDeploy integration for GitHub Actions
+
+In early 2020, [we recommended the adoption of GitHub Actions for contemporary deployments](recommendation-of-adoption.md). Absent a mature integration with CodeDeploy, we recommended apps deployed on legacy infrastructure remain on Travis CI.
+
+As of November, Travis CI throttled compute resources to open source builds, greatly increasing build times from minutes to hours or longer for our public repositories.
+
+As such, we evaluated alternatives based in GitHub Actions and now recommend that apps deployed on legacy AWS EC2 architecture are migrated to GitHub Actions, with deployments via [the `webfactory/create-aws-codedeploy-deployment` action](https://github.com/webfactory/create-aws-codedeploy-deployment).
+
+## Options evaluated
+
+### CodeDeploy actions
+
+In our initial evaluation, the big deal breaker was that we would not be able to integrate with CodeDeploy without writing custom code. As this was a huge pain point for past deployment strategies, I did not want to reintroduce it here, so I did not consider a roll-your-own solution, e.g., [use of the AWS CLI for deployment](https://docs.aws.amazon.com/cli/latest/reference/deploy/create-deployment.html).
+
+Since our initial evaluation, at least two CodeDeploy integrations have emerged:
+
+- [`webfactory/create-aws-codedeploy-deployment`](https://github.com/webfactory/create-aws-codedeploy-deployment)
+- [`byu-oit/github-action-codedeploy`](https://github.com/byu-oit/github-action-codedeploy)
+
+Per one of the maintainers, the Webfactory action [was built for internal purposes](https://github.com/datamade/how-to/issues/36#issuecomment-747288650), but it provides useful documentation and is written in clear JavaScript code, making it easy to evaluate and pilot for our own purposes.
+
+The BYU integration may be generalizable, but it appears from the README to be mostly purpose built, with uncertain maintenance futures:
+
+> Hopefully this is useful to others at BYU. Feel free to ask me some questions about it, but I make no promises about being able to commit time to support it.
+
+### Alternative strategies
+
+We also piloted an alternative to direct integration with CodeDeploy: [pushing code bundles to S3 and configuring CodeDeploy to build from the relevant S3 bucket](https://github.com/datamade/how-to/issues/36#issuecomment-736891921).
+
+This is a clever solution involving more configuration than custom code, an advantage. However, it implicates a second AWS service, S3, and the link between S3 and CodeDeploy is invisible, making migration and maintenance somewhat less straightforward than a dropin replacement for deployments via CI.
+
+If we were routinely deploying new apps on AWS infrastructure, this might be acceptable. The reality is that this change mostly implicates legacy apps with limited maintenance budgets, so ease of use is a top priority.
+
+With all of that said, if for any reason we decide to abandon direct integration with CodeDeploy, the S3 -> CodeDeploy pattern could be a reasonable fallback.
+
+## Proof of concept
+
+I piloted `webfactory/create-aws-codedeploy-deployment` in the Metro project suite:
+
+- [`la-metro-councilmatic`](https://github.com/datamade/la-metro-councilmatic)
+    - https://github.com/datamade/la-metro-councilmatic/pull/678
+    - https://github.com/datamade/la-metro-councilmatic/pull/682
+    - https://github.com/datamade/la-metro-councilmatic/pull/684
+- [`la-metro-dashboard`](https://github.com/datamade/la-metro-dashboard)
+    - https://github.com/datamade/la-metro-dashboard/pull/67
+
+## Tradeoffs
+
+Advantages of GitHub Actions for legacy apps:
+
+- Overall build time reduced from hours to minutes versus Travis CI
+- Consistent deployment practices for apps, regardless of the infrastructure they're deployed on
+- The Webfactory integration can create deployment groups on the fly, enabling a behavior similar to Heroku review apps (if we wanted it)
+
+Disadvantages of GitHub Actions for legacy apps:
+
+- The Webfactory integration does not support deployments from tags, so we have to switch to deployments from a branch
+
+## Maintenance outlook
+
+Webfactory [is a software development company in Germany](https://www.webfactory.de/en/). As with any free and open-source software, there is always the risk that the maintainers could choose to shelve or even sunset the code. Some positive signs on this front:
+
+- The current iteration of the integration works for our purposes. This will only ever not be the case if AWS makes material changes to its API.
+- When we did encounter a problem, [the maintainer was responsive and friendly](https://github.com/webfactory/create-aws-codedeploy-deployment/issues/5), offered a stopgap solution, and ultimately cut a new release with a fix.
+- Per the maintainer, the integration [was developed for internal use](https://github.com/datamade/how-to/issues/36#issuecomment-747288650). While it's still young and relatively untested, they have plans to adopt it more broadly, a good thing for mid- to long-term maintenance.
+
+If there is ever a need to switch away from this pattern, removing it is as simple as deleting a few lines in a GitHub workflow.

--- a/ci/research/recommendation-of-adoption.md
+++ b/ci/research/recommendation-of-adoption.md
@@ -2,7 +2,9 @@
 
 Based on our research, we recommend adopting GitHub Actions as our CI service of choice for **apps deployed on Heroku and Netlify**.
 
-For apps deployed on our legacy AWS EC2 infrastructure, we recommend sticking with Travis CI until a well-supported Action for working with CodeDeploy becomes available.
+~For apps deployed on our legacy AWS EC2 infrastructure, we recommend sticking with Travis CI until a well-supported Action for working with CodeDeploy becomes available.~
+
+**Note:** We originally recommended continued use of Travis CI for apps deployed on legacy AWS EC2 infrastructure, however Travis CI [recently deprioritized open source builds](https://blog.travis-ci.com/2020-11-02-travis-ci-new-billing), leading to build times on the order of hours or days. We now recommend migrating legacy applications under continued development from Travis CI to GitHub Actions. See [Amendment 1](amendment-1.md) for further research, and [our documentation on GitHub Actions](../github-actions.md) for examples and starter code.
 
 The following document records our recommended path forward for adopting GitHub Actions.
 
@@ -30,14 +32,14 @@ Advantages of GitHub Actions:
 
 There are a few downsides to GitHub Actions:
 
-- No CodeDeploy integration
+- ~No CodeDeploy integration~
 - Workflow syntax is more complicated
 - No container layer caching
 
-Due to these tradeoffs, we think that GitHub Actions is an appropriate choice for apps that are not deployed with CodeDeploy. We will keep an eye out for CodeDeploy integrations, but until those arrive, we plan to continue supporting Travis CI for our legacy AWS EC2 infrastructure.
+Due to these tradeoffs, we think that GitHub Actions is an appropriate choice ~for apps that are not deployed with CodeDeploy. We will keep an eye out for CodeDeploy integrations, but until those arrive, we plan to continue supporting Travis CI for our legacy AWS EC2 infrastructure~.
 
 ## Maintenance outlook
 
 GitHub Actions is a low-risk choice of service because it is integrated with GitHub, the third-party service that we depend on the most. However, this adoption will create a situation for at least some amount of time where we have to maintain projects on two CI services, GitHub Actions and Travis, which could potentially make long-term maintenance tricky.
 
-This situation feels tenable because we have a substantial amount of written documentation for Travis CI along with a lot of developer expertise. We don't expect that existing Travis projects will be hard to maintain, even in a future where we're almost exclusively using GitHub Actions for new apps.
+This situation feels tenable because we have a substantial amount of written documentation for Travis CI along with a lot of developer expertise. ~We don't expect that existing Travis projects will be hard to maintain, even in a future where we're almost exclusively using GitHub Actions for new apps.~


### PR DESCRIPTION
## Overview

This PR adds a recommendation of adoption for a third-party CodeDeploy integration for GitHub Actions. It also updates our GitHub Actions to cover this use case. It does _not_ add a cookiecutter for this pattern, as we don't maintain one for PyPI, another deployment edge case.

Handles #36.

## Testing Instructions

* View the rendered markdown and confirm it looks good, and that the links resolve.
* Review the prose and confirm it is clear and makes sense.