### PR TITLE
Add default Babel config and documentation to identify and transpile potentially problematic Node plugins

### DIFF
--- a/docker/templates/new-django-app/{{cookiecutter.app_name}}/README.md
+++ b/docker/templates/new-django-app/{{cookiecutter.app_name}}/README.md
@@ -22,9 +22,13 @@ on port 32001.
 
 ### Ensuring browser compatibility
 
+The default `babel.config.json` file will transpile JavaScript in your static
+directory to syntax that's friendly to modern and legacy browsers but it will
+not transpile third-party plug-ins by default.
+
 Some plug-ins target Node versions above ES5, which means that they aren't
-compatible for some browsers. Luckily, we can tell Babel to transpile these
-dependencies to ensure our apps are broadly compatible across browsers.
+compatible for older browsers. Luckily, we can tell Babel to transpile these
+dependencies to ensure our apps remain broadly compatible across browsers.
 
 To identify problematic plug-ins, you can use [the `es6-sniffer` CLI](https://github.com/hancush/python-es6-sniffer).
 

--- a/docker/templates/new-django-app/{{cookiecutter.app_name}}/README.md
+++ b/docker/templates/new-django-app/{{cookiecutter.app_name}}/README.md
@@ -26,7 +26,15 @@ Some plug-ins target Node versions above ES5, which means that they aren't
 compatible for some browsers. Luckily, we can tell Babel to transpile these
 dependencies to ensure our apps are broadly compatible across browsers.
 
-To identify problematic plug-ins, XXX.
+To identify problematic plug-ins, you can use [the `es6-sniffer` CLI](https://github.com/hancush/python-es6-sniffer).
+
+```bash
+# Build the es6-sniffer image from GitHub
+docker build -t es6-sniffer https://github.com/hancush/python-es6-sniffer.git
+
+# Sniff out potentially incompatible modules
+docker run --v {{ cookiecutter.app_name }}_{{ cookiecutter.app_name }}-node-modules:/node_modules --rm es6-sniffer
+```
 
 Once you've found the culprits, add them to the `only` array in
 `babel.config.json`. For example:
@@ -34,9 +42,9 @@ Once you've found the culprits, add them to the `only` array in
 ```json
 {
     "only": [
-        "./build_test/static", // Your JavaScript - default
+        "./{{ cookiecutter.module_name }}/static", // Your JavaScript - default
         "./node_modules/problem_module_a",
-        "/.node_modules/problem_module_b"
+        "./node_modules/problem_module_b"
     ],
     // The rest of your config
 }

--- a/docker/templates/new-django-app/{{cookiecutter.app_name}}/README.md
+++ b/docker/templates/new-django-app/{{cookiecutter.app_name}}/README.md
@@ -20,6 +20,28 @@ docker-compose up
 The app will be available at http://localhost:8000. The database will be exposed
 on port 32001.
 
+### Ensuring browser compatibility
+
+Some plug-ins target Node versions above ES5, which means that they aren't
+compatible for some browsers. Luckily, we can tell Babel to transpile these
+dependencies to ensure our apps are broadly compatible across browsers.
+
+To identify problematic plug-ins, XXX.
+
+Once you've found the culprits, add them to the `only` array in
+`babel.config.json`. For example:
+
+```json
+{
+    "only": [
+        "./build_test/static", // Your JavaScript - default
+        "./node_modules/problem_module_a",
+        "/.node_modules/problem_module_b"
+    ],
+    // The rest of your config
+}
+```
+
 ### Running tests
 
 Run tests with Docker Compose:

--- a/docker/templates/new-django-app/{{cookiecutter.app_name}}/README.md
+++ b/docker/templates/new-django-app/{{cookiecutter.app_name}}/README.md
@@ -37,7 +37,7 @@ To identify problematic plug-ins, you can use [the `es6-sniffer` CLI](https://gi
 docker build -t es6-sniffer https://github.com/hancush/python-es6-sniffer.git
 
 # Sniff out potentially incompatible modules
-docker run --v {{ cookiecutter.app_name }}_{{ cookiecutter.app_name }}-node-modules:/node_modules --rm es6-sniffer
+docker run -v {{ cookiecutter.app_name }}_{{ cookiecutter.app_name }}-node-modules:/node_modules --rm es6-sniffer
 ```
 
 Once you've found the culprits, add them to the `only` array in

--- a/docker/templates/new-django-app/{{cookiecutter.app_name}}/babel.config.json
+++ b/docker/templates/new-django-app/{{cookiecutter.app_name}}/babel.config.json
@@ -1,6 +1,6 @@
 {
     "only": [
-        "./build_test/static"
+        "./{{ cookiecutter.module_name }}/static"
     ],
     "presets": [
         [

--- a/docker/templates/new-django-app/{{cookiecutter.app_name}}/babel.config.json
+++ b/docker/templates/new-django-app/{{cookiecutter.app_name}}/babel.config.json
@@ -1,0 +1,17 @@
+{
+    "only": [
+        "./build_test/static"
+    ],
+    "presets": [
+        [
+            "@babel/preset-env", {
+                "targets": "> 0.25%, not dead",
+                "useBuiltIns": "usage",
+                "corejs": {
+                    "version": "3.8",
+                    "proposals": "true"
+                }
+            }
+        ]
+    ]
+}

--- a/docker/templates/new-django-app/{{cookiecutter.app_name}}/package.json
+++ b/docker/templates/new-django-app/{{cookiecutter.app_name}}/package.json
@@ -10,6 +10,7 @@
     "babel-preset-env": "^1.7.0",
     "babelify": "^10.0.0",
     "browserify": "^16.5.0",
+    "core-js": "^3.8.3",
     "react": "^16.13.1",
     "react-dom": "^16.13.1"
   },

--- a/docker/templates/new-django-app/{{cookiecutter.app_name}}/{{cookiecutter.module_name}}/settings.py
+++ b/docker/templates/new-django-app/{{cookiecutter.app_name}}/{{cookiecutter.module_name}}/settings.py
@@ -154,9 +154,16 @@ STATICFILES_FINDERS = (
 )
 
 # Django Compressor configs
+# This array determines which command django-compressor will run for each
+# script type (<script type="module"> for vanilla JavaScript, <script
+# type="text/jsx"> for React). CLI options are _combined_ with the options in
+# the package Babel config, babel.config.json. By default, we use the
+# @babel/preset-env preset. Need to transpile browser incompatible plugins?
+# Add them to the "only" array in babel.config.json, as documented in the
+# README under "Ensuring browser compatibility".
 COMPRESS_PRECOMPILERS = (
-    ('module', 'export NODE_PATH=/app/node_modules && npx browserify {infile} -t [ babelify --presets [ @babel/preset-env ] ] > {outfile}'),
-    ('text/jsx', 'export NODE_PATH=/app/node_modules && npx browserify {infile} -t [ babelify --presets [ @babel/preset-env @babel/preset-react ] ] > {outfile}'),
+    ('module', 'export NODE_PATH=/app/node_modules && npx browserify {infile} -t [ babelify --global ] > {outfile}'),
+    ('text/jsx', 'export NODE_PATH=/app/node_modules && npx browserify {infile} -t [ babelify --global --presets [ @babel/preset-react ] ] > {outfile}'),
 )
 
 COMPRESS_OUTPUT_DIR = 'compressor'


### PR DESCRIPTION
## Overview

See title. These changes are necessary so our Django/React integration emits JavaScript code that's compatible with both modern and legacy browsers.

Handles #149 

## Testing Instructions

* Review the prose and confirm it is clear and helpful.
* Follow the instructions to create a new Django app from our `new-django-app` Docker template.
* `cd` into your new app directory and build the app: `docker-compose build app`
* Follow the instructions in the app README to identify and transpile third-party plugins that may contain ES6 code. 
* Run your app and visit the homepage. View the page source, find the link to the compiled JavaScript, and open it in your and confirm it contains transpiled plug-in code.
