### PR TITLE
github-actions: adds .env config step to main.yml

### DIFF
--- a/ci/github-actions.md
+++ b/ci/github-actions.md
@@ -43,7 +43,7 @@ Due to the `on` block, this workflow will run the `test` job on all commits to `
 
 For most of our apps deployed to Heroku, we make use of local `.env` and `.env.example` files to store our secrets. If your app is setup this way, add these lines to the `test` block of `main.yml`
 
-```
+```yaml
 jobs:
   test:
     name: Run tests

--- a/ci/github-actions.md
+++ b/ci/github-actions.md
@@ -35,6 +35,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
+    - shell: bash
+      run: |
+        cp .env.example .env
     - name: Build containers and run tests
       run: docker-compose -f docker-compose.yml -f tests/docker-compose.yml run --rm app
 ```

--- a/ci/github-actions.md
+++ b/ci/github-actions.md
@@ -35,14 +35,27 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
+    - name: Build containers and run tests
+      run: docker-compose -f docker-compose.yml -f tests/docker-compose.yml run --rm app
+```
+
+Due to the `on` block, this workflow will run the `test` job on all commits to `master` and all commits to pull requests that have been opened against `master`.
+
+For most of our apps deployed to Heroku, we make use of local `.env` and `.env.example` files to store our secrets. If your app is setup this way, add these lines to the `test` block of `main.yml`
+
+```
+jobs:
+  test:
+    name: Run tests
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
     - shell: bash
       run: |
         cp .env.example .env
     - name: Build containers and run tests
       run: docker-compose -f docker-compose.yml -f tests/docker-compose.yml run --rm app
 ```
-
-Due to the `on` block, this workflow will run the `test` job on all commits to `master` and all commits to pull requests that have been opened against `master`.
 
 Commit this file to your feature branch and open up a pull request. You should be able to confirm that your workflow runs the tests for your pull request.
 

--- a/ci/github-actions.md
+++ b/ci/github-actions.md
@@ -41,7 +41,7 @@ jobs:
 
 Due to the `on` block, this workflow will run the `test` job on all commits to `master` and all commits to pull requests that have been opened against `master`.
 
-For most of our apps deployed to Heroku, we make use of local `.env` and `.env.example` files to store our secrets. If your app is setup this way, add these lines to the `test` block of `main.yml`
+If your tests need any additional configurations, such as a `.env` file or a local settings file, add a step to your `test` job to create or copy the necessary files, prior to running the tests. For example:
 
 ```yaml
 jobs:


### PR DESCRIPTION
## Overview

Updates our example `main.yml` for GitHub Actions to include a line for copying over `.env.example` to `.env`. From my experience, this is now our standard practice.
