### PR TITLE
updates expired link to opencivicdata.org

### DIFF
--- a/postgres/Interacting-with-a-remote-database.md
+++ b/postgres/Interacting-with-a-remote-database.md
@@ -1,6 +1,6 @@
 # Interacting with a remote database
 
-In the course of developing an application, you may want to make use of data that's stored remotely. For instance, DataMade maintains databases of the information scraped for its [Open Civic Data API](http://docs.opencivicdata.org/en/latest/api/index.html).
+In the course of developing an application, you may want to make use of data that's stored remotely. For instance, DataMade maintains databases of the information scraped for its [Open Civic Data API](https://opencivicdata.readthedocs.io/en/latest/).
 
 You can access that data directly via SSH tunneling, or binding a port on your machine to a port on a remote machine. Doing so allows your application to interact with a remote database as if it were local.
 


### PR DESCRIPTION
## Overview

The domain for `opencivicdata.org` has expired and now redirects to a potentially malicious site:

![Screen Shot 2021-07-25 at 10 09 15 AM](https://user-images.githubusercontent.com/919583/126903968-370d1f2a-30eb-4ff8-ba62-a5b280534887.png)

Unless someone in the Open Civic Data community purchases the domain from the new owner, we will need to update all `opencivicdata.org` links to point to https://opencivicdata.readthedocs.io/en/latest/

The following links are impacted:

* docs.opencivicdata.org
* api.opencivicdata.org
* opencivicdata.org

This PR updates the link in our postgres documentation to point to readthedocs.
