### PR TITLE
add fatima and sam's mapping documentation

### DIFF
--- a/mapping/README.md
+++ b/mapping/README.md
@@ -1,5 +1,12 @@
 # 🗺 Mapping, the DataMade way
 
-This directory contains documents summarizing strategies used at DataMade for building interactive slippy maps.
+Maps are flexible and widely understood tools that we use to visualize data.
 
-1. [Google APIs (Maps, Geocoding)](/mapping/google-apis.md)
+In order to put together any sort of map (except an SVG map!), you need to make sure you have GeoJSON for any geographies you will want to display. GeoJSON is a JSON format for encoding geographical data. The [GeoJSON website](http://geojson.org) has a reliable example of what this format must look like. For a deeper dive into the format, [this blog](https://macwright.com/2015/03/23/geojson-second-bite.html) post is a good place to start.
+
+Having this information, the next step is to decide what kind of functionality you will need your map to have:
+* Need a slippy map, also known as a tiled map? Use [Leaflet](/mapping/leaflet.md)
+* Are you planning to use React to render your front-end? Pay special attention to the nuances of [React-Leaflet](/mapping/react-leaflet.md)
+* Will you be using custom geographies? Use Leaflet together with PostGIS
+* Do you need to show information for geographical features like stores or parks? Make sure to use [Google APIs maps and geocoding](/mapping/google-apis.md)
+* If you don’t need a slippy map, don’t need to display geographical features, and you have access to an SVG file of the geographies you will be using, implementing an [SVG map](/mapping/svg-maps.md) is a good choice

--- a/mapping/README.md
+++ b/mapping/README.md
@@ -2,7 +2,7 @@
 
 Maps are flexible and widely understood tools that we use to visualize data.
 
-In order to put together any sort of map (except an SVG map!), you need to make sure you have GeoJSON for any geographies you will want to display. GeoJSON is a JSON format for encoding geographical data. The [GeoJSON website](http://geojson.org) has a reliable example of what this format must look like. For a deeper dive into the format, [this blog](https://macwright.com/2015/03/23/geojson-second-bite.html) post is a good place to start.
+In order to put together any sort of map (except an SVG map!), you need to make sure you have GeoJSON for any geographies you will want to display. GeoJSON is a JSON format for encoding geographical data. The [GeoJSON website](http://geojson.org) has a reliable example of what this format must look like. For a deeper dive into the format, [this blog post](https://macwright.com/2015/03/23/geojson-second-bite.html) is a good place to start. GeoJSON is limited by how much data it can render. If you GeoJSON data has 10,000 or more objects, then you should look into using a service like Carto or Mapbox. These services can handle millions of objects on a map by rasterizing their own tiles to show only the data at the zoom level and window being viewed by the user. 
 
 Having this information, the next step is to decide what kind of functionality you will need your map to have:
 * Need a slippy map, also known as a tiled map? Use [Leaflet](/mapping/leaflet.md)

--- a/mapping/leaflet.md
+++ b/mapping/leaflet.md
@@ -1,0 +1,32 @@
+# Leaflet
+[Leaflet](https://leafletjs.com/) is an open-source JavaScript library for highly interactive, mobile-friendly maps.
+
+There are two ways to use Leaflet:
+1. [Leaflet](https://leafletjs.com/) for plain JavaScript projects.
+2. [react-leaflet](https://react-leaflet.js.org/), which is for React projects. [See our documentation](/mapping/react-leaflet.md) for some guidance on how to use it.
+
+## Leaflet with vanilla JS
+The Leaflet library is a tool to use when:
+1. you need a ["slippy map"](https://wiki.openstreetmap.org/wiki/Slippy_Map)
+2. your map has a lot of interactions, more than you can manage with an SVG
+3. you have some GeoJSON or custom geographical features
+
+[The Leaflet documentation](https://leafletjs.com/) is the best place to learn the basics of Leaflet. 
+
+### Examples from DataMade projects
+- [Searchable Map Template](https://github.com/datamade/searchable-map-template-csv)
+- [Justice Divided](https://github.com/datamade/justice-divided/blob/master/js/district_map.js)
+- [Cal FWD CDI site](https://github.com/datamade/california-dream-index/blob/master/cdi/static/js/detailMap.js)
+- [Councilmatic](https://github.com/datamade/django-councilmatic/blob/5b074f376667766e4b6dbf093871d294bb35fc51/councilmatic_core/templates/councilmatic_core/council_members.html#L105)
+
+
+### Examples from Leaflet's documentation
+- [Quickstart](https://leafletjs.com/examples/quick-start/)
+- [Using GeoJSON with Leaflet](https://leafletjs.com/examples/geojson/)
+- [Interactive Choropleth Map](https://leafletjs.com/examples/choropleth/)
+ 
+### Limitations
+Leaflet with vanilla JavaScript can lead to an unorganized and hard-to-use codebase. If you have a map that might have a lot of extra functionality, then we'd recommend using [react-leaflet](/mapping/react-leaflet.md).
+
+#### Further reading
+- [Map templates for Leaflet](https://handsondataviz.org/leaflet.html)

--- a/mapping/leaflet.md
+++ b/mapping/leaflet.md
@@ -13,20 +13,20 @@ The Leaflet library is a tool to use when:
 
 [The Leaflet documentation](https://leafletjs.com/) is the best place to learn the basics of Leaflet. 
 
+### Limitations
+Leaflet with vanilla JavaScript can lead to an unorganized and hard-to-use codebase. If you have a map that might have a lot of extra functionality, then we'd recommend using [react-leaflet](/mapping/react-leaflet.md).
+
 ### Examples from DataMade projects
 - [Searchable Map Template](https://github.com/datamade/searchable-map-template-csv)
 - [Justice Divided](https://github.com/datamade/justice-divided/blob/master/js/district_map.js)
 - [Cal FWD CDI site](https://github.com/datamade/california-dream-index/blob/master/cdi/static/js/detailMap.js)
-- [Councilmatic](https://github.com/datamade/django-councilmatic/blob/5b074f376667766e4b6dbf093871d294bb35fc51/councilmatic_core/templates/partials/map.html)
+- [Councilmatic](https://github.com/datamade/django-councilmatic/blob/5b074f376667766e4b6dbf093871d294bb35fc51/councilmatic_core/templates/councilmatic_core/council_members.html#L105)
 
 
 ### Examples from Leaflet's documentation
 - [Quickstart](https://leafletjs.com/examples/quick-start/)
 - [Using GeoJSON with Leaflet](https://leafletjs.com/examples/geojson/)
 - [Interactive Choropleth Map](https://leafletjs.com/examples/choropleth/)
- 
-### Limitations
-Leaflet with vanilla JavaScript can lead to an unorganized and hard-to-use codebase. If you have a map that might have a lot of extra functionality, then we'd recommend using [react-leaflet](/mapping/react-leaflet.md).
 
 #### Further reading
 - [Map templates for Leaflet](https://handsondataviz.org/leaflet.html)

--- a/mapping/leaflet.md
+++ b/mapping/leaflet.md
@@ -17,7 +17,7 @@ The Leaflet library is a tool to use when:
 - [Searchable Map Template](https://github.com/datamade/searchable-map-template-csv)
 - [Justice Divided](https://github.com/datamade/justice-divided/blob/master/js/district_map.js)
 - [Cal FWD CDI site](https://github.com/datamade/california-dream-index/blob/master/cdi/static/js/detailMap.js)
-- [Councilmatic](https://github.com/datamade/django-councilmatic/blob/5b074f376667766e4b6dbf093871d294bb35fc51/councilmatic_core/templates/councilmatic_core/council_members.html#L105)
+- [Councilmatic](https://github.com/datamade/django-councilmatic/blob/5b074f376667766e4b6dbf093871d294bb35fc51/councilmatic_core/templates/partials/map.html)
 
 
 ### Examples from Leaflet's documentation

--- a/mapping/react-leaflet.md
+++ b/mapping/react-leaflet.md
@@ -150,34 +150,34 @@ import BaseMap from './base'
 import { GeoJSON } from 'react-leaflet'
 
 function ChicagoWardMap() {
-    const [wardBorders, setWardBorders] = useState(null)
+  const [wardBorders, setWardBorders] = useState(null)
 
-    useEffect(() => {
-        // get the geojson
-        fetch('https://raw.githubusercontent.com/datamade/chicago-judicial-elections/master/wards/wards_2012.geojson')
-            .then((res) => res.json()) // parse the response into json
-            .then((geojson) => {
-                setWardBorders(geojson) // with the geojson, set the state for wardBorders
-            })
-    }, [setWardBorders])
+  useEffect(() => {
+    // get the geojson
+    fetch('https://raw.githubusercontent.com/datamade/chicago-judicial-elections/master/wards/wards_2012.geojson')
+      .then((res) => res.json()) // parse the response into json
+      .then((geojson) => {
+        setWardBorders(geojson) // with the geojson, set the state for wardBorders
+      })
+  }, [setWardBorders])
 
-    const fill = {
-        fillColor: '#daf0ce', 
-        weight: 0.5,
-        opacity: 0.4,
-        color: '#666',
-        fillOpacity: 0.5
-    }
+  const fill = {
+    fillColor: '#daf0ce', 
+    weight: 0.5,
+    opacity: 0.4,
+    color: '#666',
+    fillOpacity: 0.5
+  }
 
-    return (
-        <BaseMap center={[41.8781, -87.6298]} zoom={10}>
-                {/* this will only show when wardBorders has a truthy value */}
-                {wardBorders && <GeoJSON
-                                    key='ward-layer'
-                                    data={wardBorders}
-                                    style={fill} />}
-        </BaseMap>
-    )
+  return (
+    <BaseMap center={[41.8781, -87.6298]} zoom={10}>
+      {/* this will only show when wardBorders has a truthy value */}
+      {wardBorders && <GeoJSON
+                        key='ward-layer'
+                        data={wardBorders}
+                        style={fill} />}
+    </BaseMap>
+  )
 }
 
 export default ChicagoWardMap
@@ -198,9 +198,9 @@ Finally, we can attach callbacks to each GeoJSON feature. This is how you can ad
 You want to send a callback function into the GeoJSON layer. The GeoJSON component includes a prop called `onEachFeature`, where you can access the GeoJSON layer within the leaflet instance. Add this method inside the scope of the `ChicagoWardMap` component:
 ```jsx
 function eventHandlersOnEachFeature(feature, layer) {
-    layer.on({
-      click: onWardClick
-    })
+  layer.on({
+    click: onWardClick
+  })
 }
 ```
 This is an undocumented method in `react-leaflet`, but it's using the underlying `leaflet` library and HTML DOM events. See [the `leaflet` documentation](https://leafletjs.com/reference-1.7.1.html#domevent) for more details.
@@ -208,23 +208,23 @@ This is an undocumented method in `react-leaflet`, but it's using the underlying
 Create the `onWardClick` function, also in the scope of `ChicagoWardMap`:
 ```jsx
 function onWardClick(e) {
-        const layer = e.target
+  const layer = e.target
 
-        const layerFeature = (layer && layer.feature && layer.feature.properties) 
-                                ? layer.feature.properties 
-                                : null
-        
-        console.log(layerFeature)
-    }
+  const layerFeature = layer?.feature?.properties
+                        ? layer.feature.properties 
+                        : null
+  
+  console.log(layerFeature)
+}
  ```
 
 To your `GeoJSON` instance, pass in the `eventHandlersOnEachFeature` function as an argument to the `onEachFeature` props:
 ```jsx
 <GeoJSON
-    key='ward-layer'
-    data={wardBorders}
-    style={fill} 
-    onEachFeature={eventHandlersOnEachFeature} />
+  key='ward-layer'
+  data={wardBorders}
+  style={fill} 
+  onEachFeature={eventHandlersOnEachFeature} />
 ```
 
 Your `src/maps/wards.js` should look like this:
@@ -234,53 +234,53 @@ import BaseMap from './base'
 import { GeoJSON } from 'react-leaflet'
 
 function ChicagoWardMap() {
-    const [wardBorders, setWardBorders] = useState(null)
+  const [wardBorders, setWardBorders] = useState(null)
 
-    useEffect(() => {
-        // get the geojson
-        fetch('https://raw.githubusercontent.com/datamade/chicago-judicial-elections/master/wards/wards_2012.geojson')
-            .then((res) => res.json())
-            .then((geojson) => {
-                setWardBorders(geojson)
-            })
+  useEffect(() => {
+    // get the geojson
+    fetch('https://raw.githubusercontent.com/datamade/chicago-judicial-elections/master/wards/wards_2012.geojson')
+      .then((res) => res.json())
+      .then((geojson) => {
+        setWardBorders(geojson)
+      })
 
-    }, [setWardBorders])
+  }, [setWardBorders])
 
-    const fill = {
-        fillColor: '#daf0ce', 
-        weight: 0.5,
-        opacity: 0.4,
-        color: '#666',
-        fillOpacity: 0.5
-    }
+  const fill = {
+    fillColor: '#daf0ce', 
+    weight: 0.5,
+    opacity: 0.4,
+    color: '#666',
+    fillOpacity: 0.5
+  }
+  
+  function onWardClick(e) {
+    const layer = e.target
+
+    const layerFeature = layer?.feature?.properties
+                          ? layer.feature.properties 
+                          : null
     
-    function onWardClick(e) {
-        const layer = e.target
+    console.log(layerFeature)
+  }
 
-        const layerFeature = (layer && layer.feature && layer.feature.properties) 
-                                ? layer.feature.properties 
-                                : null
-        
-        console.log(layerFeature)
-    }
+  function eventHandlersOnEachFeature(feature, layer) {
+    layer.on({
+      click: onWardClick
+    })
+  }
 
-    function eventHandlersOnEachFeature(feature, layer) {
-        layer.on({
-          click: onWardClick
-        })
-    }
-
-    return (
-        <div className='map-viewer'>
-            <BaseMap center={[41.8781, -87.6298]} zoom={10}>
-                {wardBorders && <GeoJSON
-                                    key='ward-layer'
-                                    data={wardBorders}
-                                    style={fill} 
-                                    onEachFeature={eventHandlersOnEachFeature} />}
-            </BaseMap>
-        </div>
-    )
+  return (
+    <div className='map-viewer'>
+      <BaseMap center={[41.8781, -87.6298]} zoom={10}>
+        {wardBorders && <GeoJSON
+                          key='ward-layer'
+                          data={wardBorders}
+                          style={fill} 
+                          onEachFeature={eventHandlersOnEachFeature} />}
+      </BaseMap>
+    </div>
+  )
 }
 
 export default ChicagoWardMap
@@ -299,13 +299,13 @@ const [ward, setWard] = useState({})
 Use the `setWard` function in your `onWardClick` function:
 ```jsx
 function onWardClick(e) {
-    const layer = e.target
+  const layer = e.target
 
-    const layerFeature = (layer && layer.feature && layer.feature.properties) 
-                            ? layer.feature.properties 
-                            : null
+  const layerFeature = layer?.feature?.properties
+                        ? layer.feature.properties 
+                        : null
 
-    setWard(layerFeature)
+  setWard(layerFeature)
 }
 ```
 
@@ -316,56 +316,55 @@ import BaseMap from './base'
 import { GeoJSON } from 'react-leaflet'
 
 function ChicagoWardMap() {
-    const [wardBorders, setWardBorders] = useState(null)
-    const [ward, setWard] = useState(null)
+  const [wardBorders, setWardBorders] = useState(null)
+  const [ward, setWard] = useState(null)
 
-    useEffect(() => {
-        // get the geojson
-        fetch('https://raw.githubusercontent.com/datamade/chicago-judicial-elections/master/wards/wards_2012.geojson')
-            .then((res) => res.json()) // parse the response into json
-            .then((geojson) => {
-                setWardBorders(geojson) // with the geojson, set the state for wardBorders
-            })
+  useEffect(() => {
+    // get the geojson
+    fetch('https://raw.githubusercontent.com/datamade/chicago-judicial-elections/master/wards/wards_2012.geojson')
+      .then((res) => res.json()) // parse the response into json
+      .then((geojson) => {
+          setWardBorders(geojson) // with the geojson, set the state for wardBorders
+      })
+  }, [setWardBorders])
 
-    }, [setWardBorders])
+  const fill = {
+    fillColor: '#daf0ce', 
+    weight: 0.5,
+    opacity: 0.4,
+    color: '#666',
+    fillOpacity: 0.5
+  }
 
-    const fill = {
-        fillColor: '#daf0ce', 
-        weight: 0.5,
-        opacity: 0.4,
-        color: '#666',
-        fillOpacity: 0.5
-    }
+  function onWardClick(e) {
+    const layer = e.target
 
-    function onWardClick(e) {
-        const layer = e.target
+    const layerFeature = layer?.feature?.properties
+                          ? layer.feature.properties 
+                          : null
+    
+    setWard(layerFeature)
+  }
 
-        const layerFeature = (layer && layer.feature && layer.feature.properties) 
-                                ? layer.feature.properties 
-                                : null
-        
-        setWard(layerFeature)
-    }
+  function eventHandlersOnEachFeature(feature, layer) {
+    layer.on({
+      click: onWardClick
+    })
+  }
 
-    function eventHandlersOnEachFeature(feature, layer) {
-        layer.on({
-          click: onWardClick
-        })
-    }
-
-    return (
-        <>
-            <BaseMap center={[41.8781, -87.6298]} zoom={10}>
-            {/* this will only show when wardBorders has a value */}
-            {wardBorders && <GeoJSON
-                                key='ward-layer'
-                                data={wardBorders}
-                                style={fill} 
-                                onEachFeature={eventHandlersOnEachFeature} />}
-            </BaseMap>
-            {ward && <p>Ward {ward.ward}'s shape_area = {ward.shape_area} and shape_leng = {ward.shape_leng}</p>}
-        </>
-    )
+  return (
+    <>
+      <BaseMap center={[41.8781, -87.6298]} zoom={10}>
+        {/* this will only show when wardBorders has a value */}
+        {wardBorders && <GeoJSON
+                          key='ward-layer'
+                          data={wardBorders}
+                          style={fill} 
+                          onEachFeature={eventHandlersOnEachFeature} />}
+      </BaseMap>
+      {ward && <p>Ward {ward.ward}'s shape_area = {ward.shape_area} and shape_leng = {ward.shape_leng}</p>}
+    </>
+  )
 }
 
 export default ChicagoWardMap
@@ -412,15 +411,15 @@ Remove these two lines of code, since you replaced them in `App.js`:
 And in the `onWardClick` function, replace the `setWard` function with `onChooseCounty`:
 ```jsx
 function onCountyClick(e) {
-        const layer = e.target
+  const layer = e.target
 
-        const layerFeature = (layer && layer.feature && layer.feature.properties) 
-                                ? layer.feature.properties 
-                                : null
+  const layerFeature = layer?.feature?.properties
+                        ? layer.feature.properties 
+                        : null
 
-        // send the information about the feature to the parent component
-        onChooseCounty(layerFeature)
-    }
+  // send the information about the feature to the parent component
+  onChooseCounty(layerFeature)
+}
 ```
 
 If you did this correctly, your map should render the same as it did. This pattern can make applications complicated, so only use it sparingly, when it's absolutely necessary.

--- a/mapping/react-leaflet.md
+++ b/mapping/react-leaflet.md
@@ -60,7 +60,7 @@ export default BaseMap
 
 This is a reusable component for making maps. Whenever you use it, you can pass props into it, like `center`, `zoom`, `className`, and `children`. The `children` argument enables you to build a map with custom layers. This is a powerful feature of React, and helps you "compose" resuable components in a way that makes sense for your UI. You will see how this works when you add the GeoJSON layer.
 
-**It's very important that you import `leaflet/dist/leaflet.css` to your `BaseMap`. This isn't obvious from the React Leaflet documentation.**
+**It's very important that you import `leaflet/dist/leaflet.css` to your `BaseMap`. This isn't obvious from the React Leaflet documentation.** If you don't show this, then the `react-leaflet` library won't have the required CSS, causing the map to render in weird, undesired ways.
 
 ### Add the CSS
 The `react-leaflet` library creates a [`<div>` element on the DOM](https://react-leaflet.js.org/docs/start-introduction#dom-rendering) when the map is rendered, and it comes with a CSS class named `leaflet-container`. You need to target this class with some height and width properties in order to show the map.

--- a/mapping/react-leaflet.md
+++ b/mapping/react-leaflet.md
@@ -218,7 +218,7 @@ function onWardClick(e) {
     }
  ```
 
-To your `GeoJSON` instance, pass in the function as an argument to the `onEachFeature` props:
+To your `GeoJSON` instance, pass in the `eventHandlersOnEachFeature` function as an argument to the `onEachFeature` props:
 ```jsx
 <GeoJSON
     key='ward-layer'

--- a/mapping/react-leaflet.md
+++ b/mapping/react-leaflet.md
@@ -291,10 +291,12 @@ Now, whenever you click on a ward in your map, it should print some information 
 ### Show the ward's information in the UI
 Printing to the console isn't very useful. So, we need get that data and render it to the UI. Once we've done that, we'll refactor the component and "lift state up" to the parent component, so that we can keep the logic for a `ChicagoWardMap` separated from the logic of what you want on other parts of the UI.
 
-Create a new stateful object in the `ChicagoWardMap` component called `ward`:
+Create a new hook in the `ChicagoWardMap` component called `ward`:
 ```jsx
 const [ward, setWard] = useState({})
 ```
+
+If you don't know what a React Hook is, then you can learn about it [from the React docs](https://reactjs.org/docs/hooks-intro.html). It's a powerful API for managing the state of your React components.
 
 Use the `setWard` function in your `onWardClick` function:
 ```jsx

--- a/mapping/react-leaflet.md
+++ b/mapping/react-leaflet.md
@@ -289,7 +289,7 @@ export default ChicagoWardMap
 Now, whenever you click on a ward in your map, it should print some information in your console.
 
 ### Show the ward's information in the UI
-Printing to the console isn't very useful. So, we need get that data and render it to the UI. Once we've done that, we'll refactor the component and "lift state up" to the parent component, so that we can keep the logic for a `ChicagoWardMap` separated from the logic of what you want on other parts of the UI.
+Printing to the console isn't very useful. So, we need get that data and render it to the UI. Once we've done that, we'll refactor the component and ["lift state up" to the parent component](https://reactjs.org/docs/lifting-state-up.html), so that we can keep the logic for a `ChicagoWardMap` separated from the logic of what you want on other parts of the UI.
 
 Create a new hook in the `ChicagoWardMap` component called `ward`:
 ```jsx

--- a/mapping/react-leaflet.md
+++ b/mapping/react-leaflet.md
@@ -311,7 +311,7 @@ function onWardClick(e) {
 }
 ```
 
-You can now use that object in your UI. Add some html to your `ChicagoWardMap` that shows the clicked object. Your `ChicagoWardMap` should look like this:
+You can now use that GeoJSON feature in your UI. Add some html to your `ChicagoWardMap` that shows the clicked object. Your `ChicagoWardMap` should look like this:
 ```jsx
 import React, { useEffect, useState } from 'react'
 import BaseMap from './base'

--- a/mapping/react-leaflet.md
+++ b/mapping/react-leaflet.md
@@ -205,7 +205,7 @@ function eventHandlersOnEachFeature(feature, layer) {
 ```
 This is an undocumented method in `react-leaflet`, but it's using the underlying `leaflet` library and HTML DOM events. See [the `leaflet` documentation](https://leafletjs.com/reference-1.7.1.html#domevent) for more details.
 
-Create the `onWardClick` function:
+Create the `onWardClick` function, also in the scope of `ChicagoWardMap`:
 ```jsx
 function onWardClick(e) {
         const layer = e.target

--- a/mapping/react-leaflet.md
+++ b/mapping/react-leaflet.md
@@ -293,7 +293,7 @@ Printing to the console isn't very useful. So, we need get that data and render 
 
 Create a new hook in the `ChicagoWardMap` component called `ward`:
 ```jsx
-const [ward, setWard] = useState({})
+const [ward, setWard] = useState(null)
 ```
 
 If you don't know what a React Hook is, then you can learn about it [from the React docs](https://reactjs.org/docs/hooks-intro.html). It's a powerful API for managing the state of your React components.
@@ -407,7 +407,7 @@ function ChicagoWardMap({ onSelectWard }) {...}
 ```
 
 Remove these two lines of code, since you replaced them in `App.js`:
-- `const [ward, setWard] = useState({})`
+- `const [ward, setWard] = useState(null)`
 - `{ward && <p>Ward {ward.ward}'s shape_area = {ward.shape_area} and shape_leng = {ward.shape_leng}</p>}`
 
 And in the `onWardClick` function, replace the `setWard` function with `onChooseCounty`:

--- a/mapping/react-leaflet.md
+++ b/mapping/react-leaflet.md
@@ -12,7 +12,7 @@ This guide will walk you through how to use React Leaflet to make an interactive
 
 This guide also shows one of several ways to compose reusable components in a React app. Hopefully, if this guide succeeds at that, then you should be able to take these lessons and apply them to your project, i.e. organize your components in a way that works for your project or makes more sense to your brain.
 
-Before you begin, you should read [the introduction section for `react-leaflet`](https://react-leaflet.js.org/docs/start-introduction), but the rest of their setup guide is lacking. This guide hopes to help others avoid that pain.
+Before you begin, you should read [the introduction section for `react-leaflet`](https://react-leaflet.js.org/docs/start-introduction).
 
 ## Setup your React app
 Assuming you have npm installed:

--- a/mapping/react-leaflet.md
+++ b/mapping/react-leaflet.md
@@ -1,0 +1,433 @@
+# React Leaflet how-to
+`react-leaflet` is an abstraction of LeafletJS for React. It provides React components for building Leaflet maps.
+
+## Examples
+- If you need a straightforward implementation, checkout the [LISC Chicago Neighborhood Development Awardees map](https://github.com/datamade/lisc-cnda-map/blob/master/app/src/components/map.js)
+- [The introduction section for `react-leaflet`](https://react-leaflet.js.org/docs/start-introduction)
+
+## react-leaflet guide
+At the time of writing, DataMade doesn't have many examples of `react-leaflet`, so this guide fills that gap.
+
+This guide will walk you through how to use React Leaflet to make an interactive map with GeoJSON. You will first make a basic map, then add GeoJSON fetching, then attach click events to each GeoJSON feature. Each feature will be clickable and render data to the UI about the clicked feature. In other words, you'll make a map where you can click on a Chicago Judicial Ward, and information about that ward will show up on the page.
+
+This guide also shows one of several ways to compose reusable components in a React app. Hopefully, if this guide succeeds at that, then you should be able to take these lessons and apply them to your project, i.e. organize your components in a way that works for your project or makes more sense to your brain.
+
+Before you begin, you should read [the introduction section for `react-leaflet`](https://react-leaflet.js.org/docs/start-introduction), but the rest of their setup guide is lacking. This guide hopes to help others avoid that pain.
+
+## Setup your React app
+Assuming you have npm installed:
+```bash
+npx create-react-app hello-leaflet
+cd hello-leaflet
+```
+
+Install `leaflet@1.7.1`, `react-leaflet@3.1.0`, and `@react-leaflet/core@1.0.2`:
+```bash
+npm install leaflet@1.7.1 react-leaflet@3.1.0 @react-leaflet/core@1.0.2
+```
+These versions are important due to an incompatibility with `react-leaflet/core` and `create-react-app`, at the time of writing. For more info about that, see this [stackoverflow with a variety of workarounds](https://stackoverflow.com/questions/67552020/how-to-fix-error-failed-to-compile-node-modules-react-leaflet-core-esm-pat), and this [Github issue about the bug](https://github.com/PaulLeCam/react-leaflet/issues/877).
+
+
+Test that your React app works:
+```bash
+npm start
+```
+
+## Create a Base Map
+In `src/maps/base.js`, create this component:
+```jsx
+import React from 'react'
+import { MapContainer, TileLayer } from 'react-leaflet'
+import 'leaflet/dist/leaflet.css'
+
+function BaseMap({ center, zoom, className, children }) {
+    return (
+      <MapContainer
+        center={center} 
+        zoom={zoom}
+        className={className}>
+          <TileLayer
+            url="https://{s}.basemaps.cartocdn.com/light_nolabels/{z}/{x}/{y}{r}.png"
+            attribution='&copy; <a href="https://www.openstreetmap.org/copyright" target="_parent">OpenStreetMap</a> contributors &copy; <a href="https://carto.com/attributions" target="_parent">CARTO</a>'
+          />
+          {children}
+      </MapContainer>
+    )
+}
+
+export default BaseMap
+```
+
+This is a reusable component for making maps. Whenever you use it, you can pass props into it, like `center`, `zoom`, `className`, and `children`. The `children` argument enables you to build a map with custom layers. This is a powerful feature of React, and helps you "compose" resuable components in a way that makes sense for your UI. You will see how this works when you add the GeoJSON layer.
+
+**It's very important that you import `leaflet/dist/leaflet.css` to your `BaseMap`. This isn't obvious from the React Leaflet documentation.**
+
+### Add the CSS
+The `react-leaflet` library creates a [`<div>` element on the DOM](https://react-leaflet.js.org/docs/start-introduction#dom-rendering) when the map is rendered, and it comes with a CSS class named `leaflet-container`. You need to target this class with some height and width properties in order to show the map.
+
+Add to `src/App.css`:
+```css
+.leaflet-container {
+  height: 100%;
+  width: 100%;
+}
+
+.map-viewer {
+  height: 550px;
+}
+```
+
+`.map-viewer` will target a parent `<div>` in which your map will live. Since `.leaflet-container` will expand the height and width of the parent container, you can use `.map-viewer` to control the sizing on the page.
+
+### Render the BaseMap
+At this point, you can import and instantiate a `BaseMap`. Replace the code in `src/App.js` with your map:
+```jsx
+import './App.css';
+import BaseMap from './maps/base'
+
+function App() {
+  return (
+    <div className="App">
+        <div className='map-viewer'>
+            <BaseMap center={[41.8781, -87.6298]} zoom={10} />
+        </div>
+    </div>
+  );
+}
+
+export default App
+```
+
+This should show a map that is centered-ish above Chicago.
+
+## Fetch and render GeoJSON
+This is where you'll make a map with some GeoJSON. We'll use the [2012 Chicago Judicial Wards GeoJSON](https://raw.githubusercontent.com/datamade/chicago-judicial-elections/master/wards/wards_2012.geojson).
+
+### Create a new component with the BaseMap
+We can use our `BaseMap` component to build a new component for a unique map. We want to create a `ChicagoWardMap` component so that we can encapsulate all the details about the map.
+
+Import the `BaseMap` component in `src/maps/wards.js` and use it in a new `ChicagoWardMap` component:
+```jsx
+import React, { useEffect, useState } from 'react'
+import BaseMap from './base'
+import { GeoJSON } from 'react-leaflet'
+
+function ChicagoWardMap() {
+    return (
+      <BaseMap center={[41.8781, -87.6298]} zoom={10}>
+      </BaseMap>
+    )
+}
+
+export default ChicagoWardMap
+```
+
+Refactor the map in `App.js`. Import the `ChicagoWardMap` component into `App.js` and replace the `BaseMap` component:
+```jsx
+import './App.css'
+import ChicagoWardMap from './maps/wards'
+
+function App() {
+  return (
+    <div className="App">
+        <div className='map-viewer'>
+            <ChicagoWardMap />
+        </div>
+    </div>
+  );
+}
+
+export default App
+```
+
+It should look the same as when you were rendering the `BaseMap` there.
+
+### Render the GeoJSON
+Now the fun part — fetch and render the GeoJSON. You're going to do all of this in the `ChicagoWardMap` component. In `src/maps/wards.js`:
+```jsx
+import React, { useEffect, useState } from 'react'
+import BaseMap from './base'
+import { GeoJSON } from 'react-leaflet'
+
+function ChicagoWardMap() {
+    const [wardBorders, setWardBorders] = useState(null)
+
+    useEffect(() => {
+        // get the geojson
+        fetch('https://raw.githubusercontent.com/datamade/chicago-judicial-elections/master/wards/wards_2012.geojson')
+            .then((res) => res.json()) // parse the response into json
+            .then((geojson) => {
+                setWardBorders(geojson) // with the geojson, set the state for wardBorders
+            })
+    }, [setWardBorders])
+
+    const fill = {
+        fillColor: '#daf0ce', 
+        weight: 0.5,
+        opacity: 0.4,
+        color: '#666',
+        fillOpacity: 0.5
+    }
+
+    return (
+        <BaseMap center={[41.8781, -87.6298]} zoom={10}>
+                {/* this will only show when wardBorders has a truthy value */}
+                {wardBorders && <GeoJSON
+                                    key='ward-layer'
+                                    data={wardBorders}
+                                    style={fill} />}
+        </BaseMap>
+    )
+}
+
+export default ChicagoWardMap
+```
+
+This code:
+- Creates getters and setters for the `wardBorder` state:  `const [wardBorders, setWardBorders] = useState(null)`.
+- `useEffect` executes when the component renders.
+    - It uses `fetch` to retrieve the geojson.
+    - Parses the geojson and sets it as the value for `wardBorder`.
+- When `wardBorder` has a value, it will be passed into the `GeoJSON` component as `data`. This should show the Chicago Judicial Ward boundaries from 2012.
+
+Note that you don't have to fetch the GeoJSON. You can import the JSON directly from a file in your React app's code. This all depends on your application's architecture. This fetching pattern would allow for more dynamic mapping, like if you wanted a user to toggle between maps and your GeoJSON was retrievable from an API.
+
+## Attach click event callbacks to each GeoJSON feature
+Finally, we can attach callbacks to each GeoJSON feature. This is how you can add logic whenever a user clicks on a feature.
+
+You want to send a callback function into the GeoJSON layer. The GeoJSON component includes a prop called `onEachFeature`, where you can access the GeoJSON layer within the leaflet instance. Add this method inside the scope of the `ChicagoWardMap` component:
+```jsx
+function eventHandlersOnEachFeature(feature, layer) {
+    layer.on({
+      click: onWardClick
+    })
+}
+```
+This is an undocumented method in `react-leaflet`, but it's using the underlying `leaflet` library and HTML DOM events. See [the `leaflet` documentation](https://leafletjs.com/reference-1.7.1.html#domevent) for more details.
+
+Create the `onWardClick` function:
+```jsx
+function onWardClick(e) {
+        const layer = e.target
+
+        const layerFeature = (layer && layer.feature && layer.feature.properties) 
+                                ? layer.feature.properties 
+                                : null
+        
+        console.log(layerFeature)
+    }
+ ```
+
+To your `GeoJSON` instance, pass in the function as an argument to the `onEachFeature` props:
+```jsx
+<GeoJSON
+    key='ward-layer'
+    data={wardBorders}
+    style={fill} 
+    onEachFeature={eventHandlersOnEachFeature} />
+```
+
+Your `src/maps/wards.js` should look like this:
+```jsx
+import React, { useEffect, useState } from 'react'
+import BaseMap from './base'
+import { GeoJSON } from 'react-leaflet'
+
+function ChicagoWardMap() {
+    const [wardBorders, setWardBorders] = useState(null)
+
+    useEffect(() => {
+        // get the geojson
+        fetch('https://raw.githubusercontent.com/datamade/chicago-judicial-elections/master/wards/wards_2012.geojson')
+            .then((res) => res.json())
+            .then((geojson) => {
+                setWardBorders(geojson)
+            })
+
+    }, [setWardBorders])
+
+    const fill = {
+        fillColor: '#daf0ce', 
+        weight: 0.5,
+        opacity: 0.4,
+        color: '#666',
+        fillOpacity: 0.5
+    }
+    
+    function onWardClick(e) {
+        const layer = e.target
+
+        const layerFeature = (layer && layer.feature && layer.feature.properties) 
+                                ? layer.feature.properties 
+                                : null
+        
+        console.log(layerFeature)
+    }
+
+    function eventHandlersOnEachFeature(feature, layer) {
+        layer.on({
+          click: onWardClick
+        })
+    }
+
+    return (
+        <div className='map-viewer'>
+            <BaseMap center={[41.8781, -87.6298]} zoom={10}>
+                {wardBorders && <GeoJSON
+                                    key='ward-layer'
+                                    data={wardBorders}
+                                    style={fill} 
+                                    onEachFeature={eventHandlersOnEachFeature} />}
+            </BaseMap>
+        </div>
+    )
+}
+
+export default ChicagoWardMap
+```
+
+Now, whenever you click on a ward in your map, it should print some information in your console.
+
+### Show the ward's information in the UI
+Printing to the console isn't very useful. So, we need get that data and render it to the UI. Once we've done that, we'll refactor the component and "lift state up" to the parent component, so that we can keep the logic for a `ChicagoWardMap` separated from the logic of what you want on other parts of the UI.
+
+Create a new stateful object in the `ChicagoWardMap` component called `ward`:
+```jsx
+const [ward, setWard] = useState({})
+```
+
+Use the `setWard` function in your `onWardClick` function:
+```jsx
+function onWardClick(e) {
+    const layer = e.target
+
+    const layerFeature = (layer && layer.feature && layer.feature.properties) 
+                            ? layer.feature.properties 
+                            : null
+
+    setWard(layerFeature)
+}
+```
+
+You can now use that object in your UI. Add some html to your `ChicagoWardMap` that shows the clicked object. Your `ChicagoWardMap` should look like this:
+```jsx
+import React, { useEffect, useState } from 'react'
+import BaseMap from './base'
+import { GeoJSON } from 'react-leaflet'
+
+function ChicagoWardMap() {
+    const [wardBorders, setWardBorders] = useState(null)
+    const [ward, setWard] = useState(null)
+
+    useEffect(() => {
+        // get the geojson
+        fetch('https://raw.githubusercontent.com/datamade/chicago-judicial-elections/master/wards/wards_2012.geojson')
+            .then((res) => res.json()) // parse the response into json
+            .then((geojson) => {
+                setWardBorders(geojson) // with the geojson, set the state for wardBorders
+            })
+
+    }, [setWardBorders])
+
+    const fill = {
+        fillColor: '#daf0ce', 
+        weight: 0.5,
+        opacity: 0.4,
+        color: '#666',
+        fillOpacity: 0.5
+    }
+
+    function onWardClick(e) {
+        const layer = e.target
+
+        const layerFeature = (layer && layer.feature && layer.feature.properties) 
+                                ? layer.feature.properties 
+                                : null
+        
+        setWard(layerFeature)
+    }
+
+    function eventHandlersOnEachFeature(feature, layer) {
+        layer.on({
+          click: onWardClick
+        })
+    }
+
+    return (
+        <>
+            <BaseMap center={[41.8781, -87.6298]} zoom={10}>
+            {/* this will only show when wardBorders has a value */}
+            {wardBorders && <GeoJSON
+                                key='ward-layer'
+                                data={wardBorders}
+                                style={fill} 
+                                onEachFeature={eventHandlersOnEachFeature} />}
+            </BaseMap>
+            {ward && <p>Ward {ward.ward}'s shape_area = {ward.shape_area} and shape_leng = {ward.shape_leng}</p>}
+        </>
+    )
+}
+
+export default ChicagoWardMap
+```
+
+Nice!
+
+### Lift state up
+One thing I don't like about the current design of the `ChicagoWardMap`: what if you need to use the ward's information elsewhere in the UI, in a place that is outside of this component? You would need to "lift state up" and set the `ward` state in a parent component. This is a common pattern in React applications, and can be difficult to understand if you're not familiar with it. It's simply a JavaScript callback that passes a message from a child component to a parent component.
+
+In your `App.js`, import the `useState` hook from React, create a `ward` state object, and render it on the page like you did in `ChicagoWardMap`:
+```jsx
+import { useState } from 'react'
+import './App.css'
+import ChicagoWardMap from './maps/wards'
+
+function App() {
+  const [ward, setWard] = useState(null)
+
+  return (
+    <div className="App">
+      <div className='map-viewer'>
+        <ChicagoWardMap 
+          onSelectWard={setWard}
+        />
+        {ward && <p>Ward {ward.ward}'s shape_area = {ward.shape_area} and shape_leng = {ward.shape_leng}</p>}
+      </div>
+    </div>
+  );
+}
+
+export default App
+```
+
+This code does what `ChicagoWardMap` did, but it depends on the `onSelectWard` prop to do this. So, we need to add that prop to the `ChicagoWardMap` component. (TODO: this is where a diff would be helpful...) Where you declare the `ChicagoWardMap` function, pass in `onSelectWard` as a prop:
+```jsx
+function ChicagoWardMap({ onSelectWard }) {...}
+```
+
+Remove these two lines of code, since you replaced them in `App.js`:
+- `const [ward, setWard] = useState({})`
+- `{ward && <p>Ward {ward.ward}'s shape_area = {ward.shape_area} and shape_leng = {ward.shape_leng}</p>}`
+
+And in the `onWardClick` function, replace the `setWard` function with `onChooseCounty`:
+```jsx
+function onCountyClick(e) {
+        const layer = e.target
+
+        const layerFeature = (layer && layer.feature && layer.feature.properties) 
+                                ? layer.feature.properties 
+                                : null
+
+        // send the information about the feature to the parent component
+        onChooseCounty(layerFeature)
+    }
+```
+
+If you did this correctly, your map should render the same as it did. This pattern can make applications complicated, so only use it sparingly, when it's absolutely necessary.
+
+## Help!
+For the full code: https://github.com/smcalilly/hello-leaflet
+
+## Resources
+- [`leaflet`](https://leafletjs.com/reference-1.7.1.html#domevent)
+- [the `leaflet` documentation for DOM events](https://leafletjs.com/reference-1.7.1.html#domevent)

--- a/mapping/svg-maps.md
+++ b/mapping/svg-maps.md
@@ -1,0 +1,15 @@
+# About SVG files
+SVG files, or scalable vector graphic files, are a unique image type that work well for making maps. Maps made with SVG files allow us access to the discrete geographies within the map using JavaScript, which also opens up client-side map rendering. This makes SVG maps a powerful tool when working with front-end frameworks like React.js.
+
+## SVG Maps
+In order to build an SVG map, you first need to find an open-source SVG image of the map you want to use. The first place you can look is the [`svg-maps`](https://github.com/VictorCazanave/svg-maps) repo, which complements the [`react-svg-map`](https://www.npmjs.com/package/react-svg-map) repo. These repos provide functionality for using SVG maps with React. If the map you want to use is not already a part of the `svg-maps` repository, [Wikimedia Commons](https://commons.wikimedia.org/w/index.php?search=filemime%3Aimage%2Fsvg%2Bxml&title=Special%3ASearch&profile=advanced&fulltext=1&advancedSearch-current=%7B%22fields%22%3A%7B%22filetype%22%3A%22image%2Fsvg%2Bxml%22%7D%7D&ns6=1) is a good place to start looking for an SVG map.
+
+Keep in mind that since SVG files are geometric representations of the image, understanding how to read an SVG file can help you edit it so that it meets your needs. [This article](https://www.sitepoint.com/svg-101-what-is-svg/) provides a bit more context about what SVG files are, and [this article](https://www.smashingmagazine.com/2019/03/svg-circle-decomposition-paths/) explains how to manually calculate the path of a circle, which will expose you to some basic SVG concepts that will allow you to tweak your SVG file. It’s also easier to remove lines than to add them in most cases, so if you’re deciding between an SVG map that is too simple and one that is too complex, opting for the complex one will usually be the better choice.
+
+If the map you need is not in the `svg-maps` repo, you can still use it in your code (and submit to the `svg-maps` repo with your shiny new SVG map!) These are the steps to do so:
+1. Download the `svg-maps` repository and follow the instructions to generate a JSON representation of the SVG map.
+2. If you wish to contribute to the `svg-maps` repository, follow all the instructions in that README to format your map consistently with the other maps available.
+3. Copy the JSON file into your project repository and add it to the `images` folder in your React or Gatsby project.
+4. Use [this proof of concept](https://github.com/fatima3558/gatsby-svg-map) as a guide to render your SVG map, paying particular attention to the `src/images/svg/` directory and the `USMap` component.
+
+Once you have your JSON version of the SVG map, you can treat this like any other props and build a map component using the `react-svg-map` package. This package takes your map’s geographies and allows you to pass props into each of the geometries programmatically. For a living example of an SVG map, check out the [Sunrise Movement’s Green Jobs site](https://greenjobsdata.com/). Unfortunately, this repository is private and not owned by DataMade, so the source code is unavailable to users unaffiliated with the Sunrise Movement.

--- a/mapping/svg-maps.md
+++ b/mapping/svg-maps.md
@@ -1,15 +1,44 @@
 # About SVG files
-SVG files, or scalable vector graphic files, are a unique image type that work well for making maps. Maps made with SVG files allow us access to the discrete geographies within the map using JavaScript, which also opens up client-side map rendering. This makes SVG maps a powerful tool when working with front-end frameworks like React.js.
+SVG files, or scalable vector graphic files, are a unique image type that work well for making maps. Maps made with SVG files allow us access to the discrete geographies within the map using JavaScript. This makes SVG maps a powerful tool when working with front-end frameworks like React.js.
 
-## SVG Maps
-In order to build an SVG map, you first need to find an open-source SVG image of the map you want to use. The first place you can look is the [`svg-maps`](https://github.com/VictorCazanave/svg-maps) repo, which complements the [`react-svg-map`](https://www.npmjs.com/package/react-svg-map) repo. These repos provide functionality for using SVG maps with React. If the map you want to use is not already a part of the `svg-maps` repository, [Wikimedia Commons](https://commons.wikimedia.org/w/index.php?search=filemime%3Aimage%2Fsvg%2Bxml&title=Special%3ASearch&profile=advanced&fulltext=1&advancedSearch-current=%7B%22fields%22%3A%7B%22filetype%22%3A%22image%2Fsvg%2Bxml%22%7D%7D&ns6=1) is a good place to start looking for an SVG map.
+### When to use (and not use) SVG maps
 
-Keep in mind that since SVG files are geometric representations of the image, understanding how to read an SVG file can help you edit it so that it meets your needs. [This article](https://www.sitepoint.com/svg-101-what-is-svg/) provides a bit more context about what SVG files are, and [this article](https://www.smashingmagazine.com/2019/03/svg-circle-decomposition-paths/) explains how to manually calculate the path of a circle, which will expose you to some basic SVG concepts that will allow you to tweak your SVG file. It’s also easier to remove lines than to add them in most cases, so if you’re deciding between an SVG map that is too simple and one that is too complex, opting for the complex one will usually be the better choice.
+SVG maps are particularly handy if:
+* you do not need topographical or detailed geographic information.
+* you need to reflect large amounts of data, particularly in React or Gatsby.
+* you need or prefer client-side rendering, as with Gatsby apps.
+* you are building a choropleth or a highly interactive map.
+* you can find an SVG file of the geography or geographies you need, whether through the [`svg-maps` repo](#react-svg-maps-and-svg-maps) or elsewhere.
 
-If the map you need is not in the `svg-maps` repo, you can still use it in your code (and submit to the `svg-maps` repo with your shiny new SVG map!) These are the steps to do so:
+SVG maps are not well-suited for:
+* working with Jinja or Django Template Language -- this is likely possible, but the tooling we use for working with SVGs is specific to React. Working with SVG maps outside of React or Gatsby will require exploring other tools and/or building functionality from scratch.
+* making slippy / tiled maps.
+* detailed geographic information, examples include:
+	* geocoding.
+	* placing pins of specific locations on a map.
+	* switching between geographic resolutions (state, county, city, census tract).
+	* laying shapes over a map that do not correspond to the shapes that make up the SVG file.
+
+
+## `react-svg-maps` and `svg-maps`
+[`react-svg-map`](https://www.npmjs.com/package/react-svg-map) allows you to turn the shapes that make up an SVG file into React components. It has a complimentary repository of SVG maps, called [`svg-maps`](https://github.com/VictorCazanave/svg-maps). Each map is contained in its own folder and has its own installation instructions. [Here](https://github.com/VictorCazanave/svg-maps/tree/master/packages) is the full list of available maps.
+
+If the map you want to use is not already a part of the `svg-maps` repository, [Wikimedia Commons](https://commons.wikimedia.org/w/index.php?search=filemime%3Aimage%2Fsvg%2Bxml&title=Special%3ASearch&profile=advanced&fulltext=1&advancedSearch-current=%7B%22fields%22%3A%7B%22filetype%22%3A%22image%2Fsvg%2Bxml%22%7D%7D&ns6=1) is a good place to start looking for an SVG map. Keep in mind that it is easier to remove lines than to add them in most cases, so if you’re deciding between an SVG map that is too simple and one that is too complex, opting for the complex one will usually be the better choice.
+
+If the map you need is not in the `svg-maps` repo, you can still use it in your code. These are the steps to do so:
 1. Download the `svg-maps` repository and follow the instructions to generate a JSON representation of the SVG map.
 2. If you wish to contribute to the `svg-maps` repository, follow all the instructions in that README to format your map consistently with the other maps available.
 3. Copy the JSON file into your project repository and add it to the `images` folder in your React or Gatsby project.
 4. Use [this proof of concept](https://github.com/fatima3558/gatsby-svg-map) as a guide to render your SVG map, paying particular attention to the `src/images/svg/` directory and the `USMap` component.
 
+You can also submit a PR for the map you generated to the `svg-maps` repository so that your map is made available to others in the future! [Here](https://github.com/VictorCazanave/svg-maps/blob/master/CONTRIBUTING.md) are the contributing instructions for the `svg-maps` repo.
+
+### Further reading and examples
+
+Keep in mind that since SVG files are geometric representations of the image, understanding how to read an SVG file can help you edit it so that it meets your needs. [This article](https://www.sitepoint.com/svg-101-what-is-svg/) provides a bit more context about what SVG files are, and [this article](https://www.smashingmagazine.com/2019/03/svg-circle-decomposition-paths/) explains how to manually calculate the path of a circle, which will expose you to some basic SVG concepts that will allow you to tweak your SVG file.
+
 Once you have your JSON version of the SVG map, you can treat this like any other props and build a map component using the `react-svg-map` package. This package takes your map’s geographies and allows you to pass props into each of the geometries programmatically. For a living example of an SVG map, check out the [Sunrise Movement’s Green Jobs site](https://greenjobsdata.com/). Unfortunately, this repository is private and not owned by DataMade, so the source code is unavailable to users unaffiliated with the Sunrise Movement.
+
+For simpler examples of the `react-svg-maps` library in action, check out some [live examples](https://victorcazanave.github.io/react-svg-map/) and the corresponding [example code](https://github.com/VictorCazanave/react-svg-map/tree/master/examples/src/components).
+
+Happy mapping!


### PR DESCRIPTION
## Overview
This PR adds mapping documentation, written by Fatima and Sam. It closes issue #184.

## Notes
For the `react-leaflet` section, we didn't have many open source examples to point to. So I tried to write a guide based on some patterns I found while learning and working with `react-leaflet`, combined with my knowledge of React. Please go through that section with a highly critical mind.

There's also some key information included in that section that isn't included in the official `react-leaflet` docs. 

## Testing Instructions
- Read documentation and suggest any edits/needs for clarification/confusing sentences/etc.
- Go through the tutorial in the react-leaflet section.
- Add any notes or information that we might be overlooking.
