### PR TITLE
replaces references to master with main across all relevant files

### DIFF
--- a/ci/github-actions.md
+++ b/ci/github-actions.md
@@ -23,11 +23,11 @@ name: CI
 on:
   push:
     branches:
-    - master
+    - main
     - deploy
   pull_request:
     branches:
-    - master
+    - main
 
 jobs:
   test:
@@ -39,7 +39,7 @@ jobs:
       run: docker-compose -f docker-compose.yml -f tests/docker-compose.yml run --rm app
 ```
 
-Due to the `on` block, this workflow will run the `test` job on all commits to `master` and all commits to pull requests that have been opened against `master`.
+Due to the `on` block, this workflow will run the `test` job on all commits to `main` and all commits to pull requests that have been opened against `main`.
 
 If your tests need any additional configurations, such as a `.env` file or a local settings file, add a step to your `test` job to create or copy the necessary files, prior to running the tests. For example:
 
@@ -84,7 +84,7 @@ jobs:
     if: startsWith(github.event.ref, 'refs/tags')
     runs-on: ubuntu-18.04
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@main
     - name: Set up Python 3.7
       uses: actions/setup-python@v1
       with:
@@ -108,14 +108,14 @@ name: Publish to Test PyPI
 on:
   push:
     branches:
-      - master
+      - main
 
 jobs:
   build-and-publish:
     name: Publish to Test PyPI
     runs-on: ubuntu-18.04
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@main
     - name: Set up Python 3.7
       uses: actions/setup-python@v1
       with:
@@ -131,7 +131,7 @@ jobs:
       continue-on-error: true
 ```
 
-Taken together, these two workflows will publish any branch merged into `master` to [test PyPI](https://test.pypi.org/) and publish tagged commits to [PyPI](https://pypi.org/). This structure parallels our practice of keeping a staging site consistent with `master` and pushing tagged commits to production. If the active package version has already been deployed to either instance, the workflows will skip the upload to that instance; this means that only commits that bump the package version in `setup.py` will result in a newly deployed package.
+Taken together, these two workflows will publish any branch merged into `main` to [test PyPI](https://test.pypi.org/) and publish tagged commits to [PyPI](https://pypi.org/). This structure parallels our practice of keeping a staging site consistent with `main` and pushing tagged commits to production. If the active package version has already been deployed to either instance, the workflows will skip the upload to that instance; this means that only commits that bump the package version in `setup.py` will result in a newly deployed package.
 
 Next, follow the instructions for [creating encrypted secrets](https://help.github.com/en/actions/automating-your-workflow-with-github-actions/creating-and-using-encrypted-secrets#creating-encrypted-secrets) and save values for `pypi_token` and `test_pypi_token`.
 
@@ -156,11 +156,11 @@ name: CI
 on:
   push:
     branches:
-      - master
+      - main
       - deploy
   pull_request:
     branches:
-      - master
+      - main
 
 jobs:
   test:
@@ -228,13 +228,13 @@ Update the values indicated inline with the 🚨 emoji. Then, append the followi
 ```yaml
 # ... deployment lifecycle config ...
 branch_config:
-  master:
+  main:
     deploymentGroupName: staging
   deploy:
     deploymentGroupName: production
 ```
 
-This workflow runs your tests, then creates a deployment conditional on your tests passing. The `deploy` action determines which deployment group, if any, it should create a deployment for using the `branch_config` you added to `.appspec.yml`. In effect, commits to `master` are deployed to staging and commits to `deploy` are deployed to production; commits to all other branches result in a no-op.
+This workflow runs your tests, then creates a deployment conditional on your tests passing. The `deploy` action determines which deployment group, if any, it should create a deployment for using the `branch_config` you added to `.appspec.yml`. In effect, commits to `main` are deployed to staging and commits to `deploy` are deployed to production; commits to all other branches result in a no-op.
 
 Next, follow the instructions for [creating encrypted secrets](https://help.github.com/en/actions/automating-your-workflow-with-github-actions/creating-and-using-encrypted-secrets#creating-encrypted-secrets) and save values for `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`, using the developer credentials in our team LastPass.
 

--- a/deployment/heroku/deploy-a-django-app.md
+++ b/deployment/heroku/deploy-a-django-app.md
@@ -150,23 +150,23 @@ Heroku can deploy commits to specific branches to different environments
 (e.g. staging vs. production).
 
 [Follow the Heroku documentation](https://devcenter.heroku.com/articles/github-integration#automatic-deploys)
-to enable automatic deploys from `master` to your staging app. **Be sure to check
+to enable automatic deploys from `main` to your staging app. **Be sure to check
 `Wait for CI to pass before deploy` to prevent broken code from being deployed!**
 
-For production deployments, create a long-lived `deploy` branch off of `master` and
+For production deployments, create a long-lived `deploy` branch off of `main` and
 configure automatic deployments from `deploy` to production.
 
 ```bash
 # create deploy branch (first deployment)
-git checkout master
-git pull origin master
+git checkout main
+git pull origin main
 git checkout -b deploy
 git push origin deploy
 
-# sync deploy branch with master and deploy to production (subsequent deployments)
-git checkout master
-git pull origin master
-git push origin master:deploy
+# sync deploy branch with main and deploy to production (subsequent deployments)
+git checkout main
+git pull origin main
+git push origin main:deploy
 ```
 
 ## Set up Slack notifications
@@ -618,7 +618,7 @@ kinds of emails being sent for review apps) because [Heroku defaults to the chea
 review app addons](https://help.heroku.com/SY28FR6H/why-aren-t-i-seeing-the-add-on-plan-specified-in-my-app-json-in-my-review-or-ci-app).
 
 ### Help! My staging pipeline doesn't have a database!
-You might deploy a review app and everything works. Then you merge your code to master, which builds a new version to the staging pipeline. But for some reason, there is no database provisioned for staging.
+You might deploy a review app and everything works. Then you merge your code to `main`, which builds a new version to the staging pipeline. But for some reason, there is no database provisioned for staging.
 
 Did you have the `manifest` CLI plugin installed when you first created the Heroku pipeline? If not, then it won't provision the Postgres add-on. [See this step](#install-the-heroku-cli-with-the-manifest-plugin).
 

--- a/deployment/heroku/research/hec-log.md
+++ b/deployment/heroku/research/hec-log.md
@@ -222,7 +222,7 @@ could also be automated with an `init_db` script in your application's language.
    ```bash
    git add heroku.yml [updated_config.py updated_script.py ...]
    git commit -m "add heroku.yml"
-   git push heroku your-branch:master
+   git push heroku your-branch:main
    ```
 
 ## Logging

--- a/deployment/netlify/README.md
+++ b/deployment/netlify/README.md
@@ -37,7 +37,7 @@ Netlify.
    for Business Cat, authenticate with Netlify, and choose the repo you want to integrate from
    the dropdown menu.
 4. For the `Branch to deploy` option, select `deploy`. If you don't have a `deploy` branch
-   yet, create one off of `master` so that you can verify the Netlify deployment.
+   yet, create one off of `main` so that you can verify the Netlify deployment.
 5. For the `Build command` option, input whatever command you use to generate
    a build of the site (e.g. `yarn build`).
 6. For the `Publish directory` option, input the directory that houses your built
@@ -70,7 +70,7 @@ Once you've deployed your site in the Netlify console, you can keep your deploym
 under version control by defining a `netlify.toml` config file in the root of your project repo.
 
 For an example of a simple `netlify.toml` file, see the [DataMade website
-repo](https://github.com/datamade/datamade.us/blob/master/netlify.toml). For
+repo](https://github.com/datamade/datamade.us/blob/main/netlify.toml). For
 full reference, see the [Netlify docs](https://www.netlify.com/docs/netlify-toml-reference/).
 
 This step isn't required for your deployment to work, but it's considered a best practice to keep

--- a/docker/templates/new-django-app/{{cookiecutter.app_name}}/.github/workflows/main.yml
+++ b/docker/templates/new-django-app/{{cookiecutter.app_name}}/.github/workflows/main.yml
@@ -3,11 +3,11 @@ name: CI
 on:
   push:
     branches:
-      - master
+      - main
       - deploy
   pull_request:
     branches:
-      - master
+      - main
 
 jobs:
   test:

--- a/search/01-lightweight.md
+++ b/search/01-lightweight.md
@@ -68,7 +68,7 @@ Levarages `django-datatables-view` to [populate a DataTables instance](https://g
 
 **[SSCE Dashboard](https://github.com/datamade/cps-ssce-dashboard) (Django)**
 
-Users can search by school name on the landing page, a simple table made [searchable](https://github.com/datamade/cps-ssce-dashboard/blob/master/cps_app/templates/cps_app/search.html#L123) with DataTables. The [filters](https://github.com/datamade/cps-ssce-dashboard/blob/master/cps_app/filters.py) use django-filter.
+Users can search by school name on the landing page, a simple table made [searchable](https://github.com/datamade/cps-ssce-dashboard/blob/main/cps_app/templates/cps_app/search.html#L123) with DataTables. The [filters](https://github.com/datamade/cps-ssce-dashboard/blob/main/cps_app/filters.py) use django-filter.
 
 **[BGA Payroll Database](https://github.com/datamade/bga-payroll/blob/9de0f4c02fde86038ee109288ab663d64c7fdf7b/data_import/admin.py) (Django)**
 

--- a/work-practices/version-control/source-control.md
+++ b/work-practices/version-control/source-control.md
@@ -31,19 +31,19 @@ Pull requests are the core of a project: they're how changes actually get made, 
 
 ## Branches
 
-In general, our projects center around the `master` branch. Continuous integration hooks like CodeDeploy should point to `master`, such that all commits to `master` are deployed to a staging instance, and tagged commits to `master` correspond to releases and are deployed to a production instance.
+In general, our projects center around the `main` branch. Continuous integration hooks like CodeDeploy should point to `main`, such that all commits to `main` are deployed to a staging instance, and tagged commits to `main` correspond to releases and are deployed to a production instance.
 
-We will sometimes make an exception to this pattern when deploying static sites to Netlify, where tags can't trigger build hooks. In that case, we deploy from `master` for a staging environment, and deploy to production from a dedicated `deploy` branch. To deploy to production, merge your change into master, pull the changes down locally, and then run `git push origin master:deploy`. That way, the `master` and `deploy` branches will always be fully in sync.
+We will sometimes make an exception to this pattern when deploying static sites to Netlify, where tags can't trigger build hooks. In that case, we deploy from `main` for a staging environment, and deploy to production from a dedicated `deploy` branch. To deploy to production, merge your change into main, pull the changes down locally, and then run `git push origin main:deploy`. That way, the `main` and `deploy` branches will always be fully in sync.
 
-We _do not_ use a `dev` branch for the vast majority of projects. During active development, create feature branches off `master`. It is often helpful to open pull requests for these feature branches during the course of work. When doing so, include "[WIP]" in the title to indicate to reviewers/teammates that your branch is in progress, or mark your pull request [as a draft](https://github.blog/2019-02-14-introducing-draft-pull-requests/).
+We _do not_ use a `dev` branch for the vast majority of projects. During active development, create feature branches off `main`. It is often helpful to open pull requests for these feature branches during the course of work. When doing so, include "[WIP]" in the title to indicate to reviewers/teammates that your branch is in progress, or mark your pull request [as a draft](https://github.blog/2019-02-14-introducing-draft-pull-requests/).
 
-Be sure to `rebase` (don't `merge`) your feature branch onto `master` from time to time to capture any underlying changes from bug fixes or integration of other feature branches.
+Be sure to `rebase` (don't `merge`) your feature branch onto `main` from time to time to capture any underlying changes from bug fixes or integration of other feature branches.
 
 ```bash
-git checkout master
+git checkout main
 git pull
 git checkout branch
-git rebase master
+git rebase main
 ```
 
-When you have completed work on your feature branch, remove "[WIP]" from the title of your pull request and request a review. Once your changes are accepted, merge the feature branch into `master`. If your pull request involved a lot of extraneous commits, such as debugging CI, merge your pull request using the [squash and merge](https://help.github.com/articles/about-pull-request-merges/#squash-and-merge-your-pull-request-commits) option. This will combine all commits on your feature branch into a single commit, eliminating the extraneous commits.
+When you have completed work on your feature branch, remove "[WIP]" from the title of your pull request and request a review. Once your changes are accepted, merge the feature branch into `main`. If your pull request involved a lot of extraneous commits, such as debugging CI, merge your pull request using the [squash and merge](https://help.github.com/articles/about-pull-request-merges/#squash-and-merge-your-pull-request-commits) option. This will combine all commits on your feature branch into a single commit, eliminating the extraneous commits.


### PR DESCRIPTION
## Overview

This PR replaces references to the `master` branch with `main`. 

My changes started in the `/docker/templates/` directory, but after doing a global search, I found reference to `master` in many other places. As all new repositories created on GitHub set the default branch to `main` and these tutorials are primarily focused on processes for new apps and repositories, it made sense to apply the `main` change everywhere, with the exception of links to existing repositories.

Handles #198 

## Testing Instructions

* ensure links work
