### PR TITLE
public setting/authentication for github docker images

### DIFF
--- a/docker/templates/new-django-app/{{cookiecutter.app_name}}/README.md
+++ b/docker/templates/new-django-app/{{cookiecutter.app_name}}/README.md
@@ -24,6 +24,14 @@ on port 32001.
 You can build docker images and deploy them to github's container registry using
 a the [github action "publish_docker.yml"](.github/workflows/publish_docker_image.yml). By default, this action is set up to [run when you ask it too manually](https://github.blog/changelog/2020-07-06-github-actions-manual-triggers-with-workflow_dispatch/). You may want to adjust this to run on commits, releases, or pushes to a deployment branch.
 
+After creating an image on a public repo, you probably want to make the package public too. Go to the package settings and change the visibility of the
+image to public. 
+
+![Screenshot 2022-03-23 at 10-54-36 Build software better together](https://user-images.githubusercontent.com/536941/159728240-4590050b-6658-4056-bdfb-4b46eb29d136.png)
+
+If you are on a private repo, [you will need to set up authentication to install an image](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry#authenticating-to-the-container-registry).
+
+
 ### Ensuring browser compatibility
 
 The default `babel.config.json` file will transpile JavaScript in your static


### PR DESCRIPTION
## Overview

Adds some documentation on making a github image public.

