### PR TITLE
add raw tags to github action expressions

### DIFF
--- a/docker/templates/new-django-app/{{cookiecutter.app_name}}/.github/workflows/publish_docker_image.yml
+++ b/docker/templates/new-django-app/{{cookiecutter.app_name}}/.github/workflows/publish_docker_image.yml
@@ -1,6 +1,6 @@
 name: Publish Docker image
 on:
-  workflow_dispatch:  
+  workflow_dispatch:
 jobs:
   push_to_registry:
     name: Push Docker image to GitHub Packages
@@ -10,10 +10,10 @@ jobs:
         uses: docker/login-action@v1
         with:
           registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          username:  {% raw %}${{ github.actor }}{% endraw %}
+          password: {% raw %}${{ secrets.GITHUB_TOKEN }}{% endraw %}
       - name: Push to GitHub Packages
         uses: docker/build-push-action@v2
         with:
           push: true
-          tags: ghcr.io/${{ github.repository }}:latest
+          tags: ghcr.io/{% raw %}${{ github.repository }}{% endraw %}:latest


### PR DESCRIPTION
## Overview

Fixes a cookiecutter issue with new GH action for docker registry.

## Testing Instructions
- Recreate the bug:
  - pull down main
  - create a new django app from the template and see error
- Fix:
  - pull down `add-raw` branch
  - create a new django app from the template
  - make sure your `~/publish_docker_image.yml` looks like [it does on the main branch](https://github.com/datamade/how-to/blob/main/docker/templates/new-django-app/%7B%7Bcookiecutter.app_name%7D%7D/.github/workflows/publish_docker_image.yml)