### PR TITLE
Document leaflet and general mapping a11y

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ _In alphabetical order and including links to external repository-based document
     - [Slack](logging/slack.md)
 - [Mapping](mapping/)
     - [Google APIs (Maps, Geocoding)](mapping/google-apis.md)
+    - [Leaflet](mapping/leaflet.md)
 - [PostgreSQL](postgres/)
     - [A quick and dirty introduction to `sqlalchemy`](postgres/quick-n-dirty-sqlalchemy.md)
     - [Interacting with a remote database](postgres/Interacting-with-a-remote-database.md)

--- a/mapping/accessibility.md
+++ b/mapping/accessibility.md
@@ -1,0 +1,14 @@
+# Tips for General Mapping Accessibility
+
+#### Is your data tabular?
+If your data was tabular to begin with, consider making that:
+- available for download, or 
+- available for display on the same or another page.
+
+This has the added benefit of sidestepping difficulties with making the map itself functionally accessible, since all the data will be present and digestible elsewhere.
+
+
+#### Do you have lots of keyboard navigable elements on your map?
+If your map has a ton of elements that can be tabbed through, and also has more content underneath it, consider adding in a skip block.
+
+[Skip blocks](https://webflow.com/made-in-webflow/website/Skip-Blocks) are normally recommended for elements that are repeated across multiple different pages (i.e nav bars). But in the case of the [Chicago Recovery Plan's](https://chirecoveryplan.com/) homepage map, there are 75+ elements to tab through before you can focus on the content below the map. This kind of skip block is more of a nice quality of life feature.

--- a/mapping/leaflet.md
+++ b/mapping/leaflet.md
@@ -30,3 +30,12 @@ Leaflet with vanilla JavaScript can lead to an unorganized and hard-to-use codeb
 
 #### Further reading
 - [Map templates for Leaflet](https://handsondataviz.org/leaflet.html)
+
+### A Note on Leaflet Accessibility
+[Their accessibility docs](https://leafletjs.com/examples/accessibility/) describe some features that come built into Leaflet. These are: 
+- the map is keyboard navigable by default, and 
+- the strong recommendation to add alt attributes to markers
+
+Although not described in their docs at the time of writing, sifting through issues on Leaflet’s repo shows there is a feature where polygons with tooltips are meant to have screen-readers read those tooltips as the shape's alt attribute. When testing the map on the homepage of the [Chicago Recovery Plan's dashboard](https://chirecoveryplan.com/) with VoiceOver, this feature was cumbersome. Each shape was read aloud as “graphics symbol” instead of something like “Fuller Park”. Through a series of commands, you can eventually get it to read the tooltip, but doing that for each area isn't ideal.
+
+There is a possibility that this is a VoiceOver specific issue, but we would need access to some other screen readers to be sure.


### PR DESCRIPTION
## Overview

This adds documentation on leaflet's built in accessibility and general tips for mapping a11y.

Closes #222, closes #328 

## Testing Instructions

* Read through to make sure that everything makes sense.