### PR TITLE
add matomo tag to cookiecutter templates

### DIFF
--- a/docker/templates/new-django-app/{{cookiecutter.app_name}}/{{cookiecutter.module_name}}/templates/{{cookiecutter.module_name}}/base.html
+++ b/docker/templates/new-django-app/{{cookiecutter.app_name}}/{{cookiecutter.module_name}}/templates/{{cookiecutter.module_name}}/base.html
@@ -124,14 +124,22 @@
     <script src="{% static 'js/lib/fontawesome.min.js' %}"></script>
     <script src="{% static 'js/lib/solid.min.js' %}"></script>
 
-    <!-- Load Google Tag Manager for analytics (no-op until APIKEY is set) -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=APIKEY"></script>
+    <!-- Matomo -->
     <script>
-      window.dataLayer = window.dataLayer || [];
-      function gtag(){dataLayer.push(arguments);}
-      gtag('js', new Date());
-      gtag('config', 'APIKEY');
+      var _paq = window._paq = window._paq || [];
+      /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+      _paq.push(['trackPageView']);
+      _paq.push(['enableLinkTracking']);
+      (function() {
+        var u="https://datamade.matomo.cloud/";
+        _paq.push(['setTrackerUrl', u+'matomo.php']);
+        // replace ZZZ with your site ID
+        _paq.push(['setSiteId', 'ZZZ']);
+        var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+        g.async=true; g.src='//cdn.matomo.cloud/datamade.matomo.cloud/matomo.js'; s.parentNode.insertBefore(g,s);
+      })();
     </script>
+    <!-- End Matomo Code -->
 
     <!-- Load extra external scripts -->
     {% block extra_js %}{% endblock %}

--- a/docker/templates/new-vanilla-js-app/{{cookiecutter.directory_name}}/index.html
+++ b/docker/templates/new-vanilla-js-app/{{cookiecutter.directory_name}}/index.html
@@ -90,13 +90,21 @@
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.6.0/dist/js/bootstrap.bundle.min.js" integrity="sha384-Piv4xVNRyMGpqkS2by6br4gNJ7DXjqk09RmUpJ8jgGtD7zP9yug3goQfGII0yAns" crossorigin="anonymous"></script>
     <script src="js/bundle.js"></script>
 
-    <!-- Load Google Tag Manager for analytics (no-op until APIKEY is set) -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=APIKEY"></script>
+    <!-- Matomo -->
     <script>
-      window.dataLayer = window.dataLayer || [];
-      function gtag(){dataLayer.push(arguments);}
-      gtag('js', new Date());
-      gtag('config', 'APIKEY');
+      var _paq = window._paq = window._paq || [];
+      /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+      _paq.push(['trackPageView']);
+      _paq.push(['enableLinkTracking']);
+      (function() {
+        var u="https://datamade.matomo.cloud/";
+        _paq.push(['setTrackerUrl', u+'matomo.php']);
+        // replace ZZZ with your site ID
+        _paq.push(['setSiteId', 'ZZZ']);
+        var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+        g.async=true; g.src='//cdn.matomo.cloud/datamade.matomo.cloud/matomo.js'; s.parentNode.insertBefore(g,s);
+      })();
     </script>
+    <!-- End Matomo Code -->
   </body>
 </html>{% endraw %}

--- a/docker/templates/new-wagtail-app/{{ cookiecutter.app_name }}/{{ cookiecutter.module_name }}/templates/{{ cookiecutter.module_name }}/base.html
+++ b/docker/templates/new-wagtail-app/{{ cookiecutter.app_name }}/{{ cookiecutter.module_name }}/templates/{{ cookiecutter.module_name }}/base.html
@@ -117,14 +117,22 @@
              <script src="{% static 'js/lib/bootstrap.bundle.min.js' %}"></script>
              <script src="{% static 'js/lib/fontawesome.min.js' %}"></script>{% endraw %}
 
-    <!-- Load Google Tag Manager for analytics (no-op until APIKEY is set) -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=APIKEY"></script>
+    <!-- Matomo -->
     <script>
-      window.dataLayer = window.dataLayer || [];
-      function gtag(){dataLayer.push(arguments);}
-      gtag('js', new Date());
-      gtag('config', 'APIKEY');
+      var _paq = window._paq = window._paq || [];
+      /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+      _paq.push(['trackPageView']);
+      _paq.push(['enableLinkTracking']);
+      (function() {
+        var u="https://datamade.matomo.cloud/";
+        _paq.push(['setTrackerUrl', u+'matomo.php']);
+        // replace ZZZ with your site ID
+        _paq.push(['setSiteId', 'ZZZ']);
+        var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+        g.async=true; g.src='//cdn.matomo.cloud/datamade.matomo.cloud/matomo.js'; s.parentNode.insertBefore(g,s);
+      })();
     </script>
+    <!-- End Matomo Code -->
 
     <!-- Load extra external scripts -->
     {% raw %}{% block extra_js %}{% endblock %}{% endraw %}


### PR DESCRIPTION
## Overview

Removes Google analytics tag from cookie cutter templates and replaces with Matomo

* closes #333 

