### PR TITLE
Update Node install script in Cookiecutter Dockerfiles

### DIFF
--- a/docker/templates/new-django-app/cookiecutter.json
+++ b/docker/templates/new-django-app/cookiecutter.json
@@ -4,6 +4,7 @@
   "module_name": "my_new_app",
   "run_command": "python manage.py runserver 0.0.0.0:8000",
   "auto_migrate": true,
+  "node_version": 21,
   "postgis": false,
   "pg_version": "15",
   "pg_db": "database"

--- a/docker/templates/new-django-app/{{cookiecutter.app_name}}/Dockerfile
+++ b/docker/templates/new-django-app/{{cookiecutter.app_name}}/Dockerfile
@@ -9,9 +9,13 @@ FROM python:3.11
 # Give ourselves some credit
 LABEL maintainer "DataMade <info@datamade.us>"
 
-# Add the NodeSource PPA
+# Add the NodeSource PPA and install Node.js
 # (see: https://github.com/nodesource/distributions/blob/master/README.md)
-RUN curl -sL https://deb.nodesource.com/setup_18.x | bash -
+RUN apt-get update \
+	&& apt-get install sudo \ 
+	&& curl -fsSL https://deb.nodesource.com/setup_{{ cookiecutter.node_version }}.x | sudo -E bash - \
+	&& sudo apt-get install -y nodejs
+
 
 # Install any additional OS-level packages you need via apt-get. RUN statements
 # add additional layers to your image, increasing its final size. Keep your

--- a/docker/templates/new-wagtail-app/cookiecutter.json
+++ b/docker/templates/new-wagtail-app/cookiecutter.json
@@ -1,5 +1,6 @@
 {
   "app_name": "new-project",
   "module_name": "project",
-  "app_verbose_name": "Site Name"
+  "app_verbose_name": "Site Name",
+  "node_version": 21
 }

--- a/docker/templates/new-wagtail-app/{{ cookiecutter.app_name }}/Dockerfile
+++ b/docker/templates/new-wagtail-app/{{ cookiecutter.app_name }}/Dockerfile
@@ -4,14 +4,17 @@
 # version number in the pilot. YMMV. See this post for a discussion of
 # some options and their pros and cons:
 # https://pythonspeed.com/articles/base-image-python-docker-images/
-FROM python:3.9
+FROM python:3.11
 
 # Give ourselves some credit
 LABEL maintainer "DataMade <info@datamade.us>"
 
-# Add the NodeSource PPA
+# Add the NodeSource PPA and install Node.js
 # (see: https://github.com/nodesource/distributions/blob/master/README.md)
-RUN curl -sL https://deb.nodesource.com/setup_12.x | bash -
+RUN apt-get update \
+	&& apt-get install sudo \ 
+	&& curl -fsSL https://deb.nodesource.com/setup_{{ cookiecutter.node_version }}.x | sudo -E bash - \
+	&& sudo apt-get install -y nodejs
 
 # Install any additional OS-level packages you need via apt-get. RUN statements
 # add additional layers to your image, increasing its final size. Keep your


### PR DESCRIPTION
## Overview

See title.

Handles #346 

## Testing Instructions

* Create cookiecutter Django and Wagtail projects
* Verify that `docker-compose build` runs without error