### PR TITLE
Add extra details on using business cat for deployment

### DIFF
--- a/deployment/netlify/README.md
+++ b/deployment/netlify/README.md
@@ -33,9 +33,9 @@ Netlify.
    We currently use a shared account because we don't have access to Netlify Teams.
 2. In the console, choose `New site from Git` to configure your app.
 3. Select the `GitHub` provider. Netlify will ask you to authenticate with GitHub. We
-   use [Business Cat](http://github.com/business-cat) for this purpose. Get credentials
-   for Business Cat, authenticate with Netlify, and choose the repo you want to integrate from
-   the dropdown menu.
+   use [Business Cat](http://github.com/business-cat) for this purpose. Get credentials for Business Cat,
+   [add it as a collaborator](https://github.com/datamade/deploy-a-site/blob/master/Private-dependencies.md) to the repo you want to integrate,
+   authenticate with Netlify, and choose the repo from the dropdown menu.
 4. For the `Branch to deploy` option, select `deploy`. If you don't have a `deploy` branch
    yet, create one off of `main` so that you can verify the Netlify deployment.
 5. For the `Build command` option, input whatever command you use to generate

--- a/deployment/netlify/README.md
+++ b/deployment/netlify/README.md
@@ -24,7 +24,11 @@ and come back here when you're ready to deploy your app.
 ## Deploy a static site to Netlify
 
 The following instructions will help you set up a static site deployment with
-Netlify.
+Netlify. We use [Business Cat](http://github.com/business-cat) for this purpose.
+Business Cat is a machine user that allows us to build and/or install dependencies
+from private GitHub repositories. Using a machine account, rather than a personal account,
+guards against deployment failures if someone leaves DataMade or is otherwise removed
+from a private repository.
 
 ### Create a Netlify site and publish the first build
 
@@ -32,10 +36,9 @@ Netlify.
    Netlify account. (The credentials can be found in the shared DataMade LastPass under `Netlify`.)
    We currently use a shared account because we don't have access to Netlify Teams.
 2. In the console, choose `New site from Git` to configure your app.
-3. Select the `GitHub` provider. Netlify will ask you to authenticate with GitHub. We
-   use [Business Cat](http://github.com/business-cat) for this purpose. Get credentials for Business Cat,
-   [add it as a collaborator](https://github.com/datamade/deploy-a-site/blob/master/Private-dependencies.md) to the repo you want to integrate,
-   authenticate with Netlify, and choose the repo from the dropdown menu.
+3. Select the `GitHub` provider. Netlify will ask you to authenticate with GitHub.
+   Get credentials for Business Cat, [add it as a collaborator](https://github.com/datamade/deploy-a-site/blob/master/Private-dependencies.md)
+   to the repo you want to integrate, authenticate with Netlify, and choose the repo from the dropdown menu.
 4. For the `Branch to deploy` option, select `deploy`. If you don't have a `deploy` branch
    yet, create one off of `main` so that you can verify the Netlify deployment.
 5. For the `Build command` option, input whatever command you use to generate


### PR DESCRIPTION
## Overview

This references our `deploy-a-site` docs in order to include instructions on adding Business Cat as a collaborator when deploying a Netlify app, and adds some context as to why we're using it.

- Connects #364 

## Testing Instructions

* Confirm whether those docs and added details help
